### PR TITLE
Version bump to test NuGet package delivery pipeline

### DIFF
--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>


### PR DESCRIPTION
I created a private delivery pipeline for NuGet packages using PrecisionLender's internal CI system. We can use this to publish new packages until we create a public delivery pipeline.

This version bump will enable us to test the delivery pipeline. If it works, we should see the new package version upload successfully to NuGet.org.