### PR TITLE
Fixed unique names for when the current thread name is null

### DIFF
--- a/Boa.Constrictor.UnitTests/Utilities/NamesTest.cs
+++ b/Boa.Constrictor.UnitTests/Utilities/NamesTest.cs
@@ -12,31 +12,25 @@ namespace Boa.Constrictor.UnitTests.Utilities
         [Test]
         public void ConcatUniqueName_NoSuffix()
         {
-            Names.ConcatUniqueName("name").Should().MatchRegex(@"^name_\d+_[A-Za-z0-9]+$");
+            Names.ConcatUniqueName("name").Should().MatchRegex(@"^name_\d+(_[A-Za-z0-9]+)?$");
         }
 
         [Test]
         public void ConcatUniqueName_NameWithWhitespace()
         {
-            Names.ConcatUniqueName("   name  ").Should().MatchRegex(@"^name_\d+_[A-Za-z0-9]+$");
+            Names.ConcatUniqueName("   name  ").Should().MatchRegex(@"^name_\d+(_[A-Za-z0-9]+)?$");
         }
 
         [Test]
         public void ConcatUniqueName_Suffix()
         {
-            Names.ConcatUniqueName("name", "7").Should().MatchRegex(@"^name_\d+_7_[A-Za-z0-9]+$");
+            Names.ConcatUniqueName("name", "7").Should().MatchRegex(@"^name_\d+_7(_[A-Za-z0-9]+)?$");
         }
 
         [Test]
         public void ConcatUniqueName_WhitespaceSuffix()
         {
-            Names.ConcatUniqueName("name", "   ").Should().MatchRegex(@"^name_\d+_[A-Za-z0-9]+$");
-        }
-
-        [Test]
-        public void GetCurrentThreadName()
-        {
-            Names.GetCurrentThreadName().Should().MatchRegex(@"^[A-Za-z0-9]+$");
+            Names.ConcatUniqueName("name", "   ").Should().MatchRegex(@"^name_\d+(_[A-Za-z0-9]+)?$");
         }
 
         #endregion

--- a/Boa.Constrictor/Utilities/Names.cs
+++ b/Boa.Constrictor/Utilities/Names.cs
@@ -20,7 +20,6 @@ namespace Boa.Constrictor.Utilities
         public static string ConcatUniqueName(string name, string suffix = null)
         {
             string trimmed = name.Trim();
-            string thread = GetCurrentThreadName();
             string timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmssffff");
 
             string unique = $"{trimmed}_{timestamp}";
@@ -28,17 +27,10 @@ namespace Boa.Constrictor.Utilities
             if (!string.IsNullOrWhiteSpace(suffix))
                 unique += '_' + suffix;
 
-            if (!string.IsNullOrWhiteSpace(thread))
-                unique += '_' + thread;
+            if (!string.IsNullOrWhiteSpace(Thread.CurrentThread.Name))
+                unique += '_' + Regex.Replace(Thread.CurrentThread.Name, @"[^A-Za-z0-9]+", "");
 
             return unique;
         }
-
-        /// <summary>
-        /// Returns the current thread name in a format safe to use for file names.
-        /// </summary>
-        /// <returns>The current thread name in a format safe to use for file names.</returns>
-        public static string GetCurrentThreadName() =>
-            Regex.Replace(Thread.CurrentThread.Name, @"[^A-Za-z0-9]+", "");
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(None)
+### Fixed
+
+- Fixed namespace for `SwitchWindowToLatest` Task
+- Fixed broken README link
+- Fixed `Names.ConcatUniqueName` for when the current thread's name is `null`
 
 
 ## [0.2.3] - 2020-10-27


### PR DESCRIPTION
I discovered that when the current thread's name is null (`System.Threading.Thread.CurrentThread.Name`), methods in the `Names` class would break on a null pointer exception. This pull request fixes that problem.

This change removes the `GetCurrentThreadName`. This is a public method, so anyone using it would be broken. However, the user base is super small right now, and the PL test solution does not call it directly.