### PR TITLE
Added nuget-publish.yml

### DIFF
--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -1,0 +1,49 @@
+# Builds and publishes the Boa.Constrictor package to NuGet.org.
+# The NuGet key is currently Andy Knight's Q2 NuGet account.
+
+name: Publish Boa.Constrictor NuGet Package
+
+on:
+  push:
+    branches:
+      - main
+      
+jobs:
+  publish:
+    name: Publish
+    runs-on: windows-latest
+    steps:
+    
+      - name: Check out repository
+        uses: actions/checkout@v2
+        
+      - name: Publish Package on Version Change
+        id: publish_nuget
+        uses: rohith/publish-nuget@v2
+        with:
+          # Filepath of the project to be packaged, relative to root of repository
+          PROJECT_FILE_PATH: Boa.Constrictor/Boa.Constrictor.csproj
+          
+          # NuGet package id, used for version detection & defaults to project name
+          PACKAGE_NAME: Boa.Constrictor
+          
+          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
+          VERSION_FILE_PATH: Boa.Constrictor/Boa.Constrictor.csproj
+
+          # Regex pattern to extract version info in a capturing group
+          VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
+          
+          # Flag to toggle git tagging, enabled by default
+          TAG_COMMIT: true
+
+          # Format of the git tag, [*] gets replaced with actual version
+          TAG_FORMAT: v*
+
+          # API key to authenticate with NuGet server
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+
+          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
+          NUGET_SOURCE: https://api.nuget.org
+
+          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
+          INCLUDE_SYMBOLS: true

--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -5,8 +5,7 @@ name: Publish Boa.Constrictor NuGet Package
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
       
 jobs:
   publish:


### PR DESCRIPTION
This new workflow should build and publish a new Boa.Constrictor NuGet package to NuGet.org whenever we change the version in the .csproj file. Warning: it hasn't been tested yet. We need to put it in place before we can test it.

It uses the following GitHub Action:
https://github.com/marketplace/actions/publish-nuget