### PR TITLE
Added StaleElementReferenceException retries to AbstractWebLocatorTask

### DIFF
--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.3.0</Version>
+    <Version>0.3.1-alpha</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/WebDriver/Extensions/AbstractWebLocatorTask.cs
+++ b/Boa.Constrictor/WebDriver/Extensions/AbstractWebLocatorTask.cs
@@ -1,4 +1,8 @@
-﻿namespace Boa.Constrictor.WebDriver
+﻿using Boa.Constrictor.Screenplay;
+using Boa.Constrictor.Utilities;
+using OpenQA.Selenium;
+
+namespace Boa.Constrictor.WebDriver
 {
     /// <summary>
     /// Abstract class for any Web tasks that use a Web element locator.
@@ -30,6 +34,23 @@
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Attempts the task.
+        /// Internally calls RequestAs with the WebDriver from the BrowseTheWeb ability.
+        /// Internally retries the interaction if StaleElementReferenceException happens.
+        /// </summary>
+        /// <param name="actor">The screenplay actor.</param>
+        public override void PerformAs(IActor actor)
+        {
+            bool attempt()
+            {
+                PerformAs(actor, actor.Using<BrowseTheWeb>().WebDriver);
+                return true;
+            }
+                
+            Retries.RetryOnException<StaleElementReferenceException, bool>(attempt, ToString(), logger: actor.Logger);
+        }
 
         /// <summary>
         /// Returns a description of the task.

--- a/Boa.Constrictor/WebDriver/Extensions/AbstractWebTask.cs
+++ b/Boa.Constrictor/WebDriver/Extensions/AbstractWebTask.cs
@@ -26,7 +26,7 @@ namespace Boa.Constrictor.WebDriver
         /// Internally calls PerformAs with the WebDriver from the BrowseTheWeb ability.
         /// </summary>
         /// <param name="actor">The actor.</param>
-        public void PerformAs(IActor actor) => PerformAs(actor, actor.Using<BrowseTheWeb>().WebDriver);
+        public virtual void PerformAs(IActor actor) => PerformAs(actor, actor.Using<BrowseTheWeb>().WebDriver);
 
         /// <summary>
         /// Returns a description of the task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added `nuget-push.xml` to `GitHub Actions` solution folder
+- Added `StaleElementReferenceException` retries to Web locator tasks
 
 
 ## [0.3.0] - 2020-11-12


### PR DESCRIPTION
While running PrecisionLender tests, I discovered that Web locator tasks did not have automatic retries whenever a `StaleElementReferenceException` happens. (Web locator questions already had this protection.)

This pull request adds the retry logic. It also includes an "alpha" version bump because I want to test it thoroughly before making this fix official.