### PR TITLE
Added the `Rest` class to provide more fluent builder methods for RestSharp Questions

### DIFF
--- a/Boa.Constrictor.UnitTests/Boa.Constrictor.UnitTests.csproj
+++ b/Boa.Constrictor.UnitTests/Boa.Constrictor.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Moq" Version="4.15.1" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.11.4" />
+    <PackageReference Include="RestSharp" Version="106.11.7" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <None Include="../LICENSE.md" Pack="true" PackagePath="$(PackageLicenseFile)" />

--- a/Boa.Constrictor/RestSharp/Questions/Rest.cs
+++ b/Boa.Constrictor/RestSharp/Questions/Rest.cs
@@ -1,0 +1,54 @@
+﻿using RestSharp;
+
+namespace Boa.Constrictor.RestSharp
+{
+    /// <summary>
+    /// Provides more fluent calls for RestSharp Questions.
+    /// For example, `Actor.Calls(Rest.Request("...", request))` reads much better than `Actor.AsksFor(RestApiResponse.From("...", request))`.
+    /// </summary>
+    public static class Rest
+    {
+        /// <summary>
+        /// More concise builder for RestCookie.
+        /// Recommended usage: `Actor.AsksFor(Rest.Cookie("...", "..."))`
+        /// </summary>
+        /// <param name="baseUrl">The base URL for the request.</param>
+        /// <param name="name">The cookie name.</param>
+        /// <param name="expirationMinutes">The minutes to add to the current time for resetting cookie expiration.</param>
+        /// <returns></returns>
+        public static RestCookie Cookie(string baseUrl, string name, int? expirationMinutes = null) =>
+            RestCookie.Named(baseUrl, name).AndResetExpirationTo(expirationMinutes);
+
+        /// <summary>
+        /// More fluent builder for RestFileDownload.
+        /// Recommended usage: `Actor.Calls(Rest.Download("...", request, "..."))`
+        /// </summary>
+        /// <param name="baseUrl">The base URL for the request.</param>
+        /// <param name="request">The REST request to call.</param>
+        /// <param name="fileExtension">The extension for the file to download.</param>
+        /// <returns></returns>
+        public static RestFileDownload Download(string baseUrl, IRestRequest request, string fileExtension = null) =>
+            RestFileDownload.From(baseUrl, request, fileExtension);
+
+        /// <summary>
+        /// More fluent builder for RestApiResponse.
+        /// Recommended usage: `Actor.Calls(Rest.Request("...", request))`.
+        /// </summary>
+        /// <param name="baseUrl">The base URL for the request.</param>
+        /// <param name="request">The REST request to call.</param>
+        /// <returns></returns>
+        public static RestApiResponse Request(string baseUrl, IRestRequest request) =>
+            RestApiResponse.From(baseUrl, request);
+
+        /// <summary>
+        /// More fluent builder for RestApiResponse<typeparamref name="TData"/>.
+        /// Recommended usage: `Actor.Calls(Rest.Request<typeparamref name="TData"/>("...", request))`.
+        /// </summary>
+        /// <typeparam name="TData">The deserialization object type.</typeparam>
+        /// <param name="baseUrl">The base URL for the request.</param>
+        /// <param name="request">The REST request to call.</param>
+        /// <returns></returns>
+        public static RestApiResponse<TData> Request<TData>(string baseUrl, IRestRequest request) =>
+            RestApiResponse<TData>.From(baseUrl, request);
+    }
+}

--- a/Boa.Constrictor/RestSharp/Questions/RestApiResponse.cs
+++ b/Boa.Constrictor/RestSharp/Questions/RestApiResponse.cs
@@ -162,7 +162,6 @@ namespace Boa.Constrictor.RestSharp
     /// </summary>
     /// <typeparam name="TData">The response data type for deserialization.</typeparam>
     public class RestApiResponse<TData> : AbstractRestApiResponse, IQuestion<IRestResponse<TData>>
-        where TData : new()
     {
         #region Constructors
 

--- a/Boa.Constrictor/RestSharp/Questions/RestCookie.cs
+++ b/Boa.Constrictor/RestSharp/Questions/RestCookie.cs
@@ -57,7 +57,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="minutes">The minutes to add to the current time for resetting cookie expiration.</param>
         /// <returns></returns>
-        public RestCookie AndResetExpirationTo(int minutes)
+        public RestCookie AndResetExpirationTo(int? minutes)
         {
             ExpirationMinutes = minutes;
             return this;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.5.1] - 2020-12-01
+
+### Added
+
+- Added the `Rest` class to provide more fluent builder methods for RestSharp Questions
+
+
 ## [0.5.0] - 2020-11-30
 
 ### Added


### PR DESCRIPTION
| Old Call | New Call |
| --- | --- |
| `Actor.AsksFor(RestApiResponse.From("...", request))` | `Actor.Calls(Rest.Request("...", request))` |
| `Actor.AsksFor(RestFileDownload.From("...", request, ".pdf"))` | `Actor.Calls(Rest.Download("...", request, ".pdf"))` |
| `Actor.AsksFor(RestCookie.Named("...", "name"))` | `Actor.AsksFor(Rest.Cookie("...", "name"))` |

The old calls will still work. They will be backwards compatible. However, the new calls are recommended. (The new `RestCookie` call isn't absolutely necessary, but I included it for consistency with all other RestSharp Questions.)

Boa Constrictor unit tests passed. I also ran this update with PL tests to verify correctness.

**This pull request also increases the project version to 0.5.1 and will trigger a new release!**