### PR TITLE
Added LastRequest and LastResponse to RestSharp Abilities

### DIFF
--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/RestSharp/Abilities/AbstractRestSharpAbility.cs
+++ b/Boa.Constrictor/RestSharp/Abilities/AbstractRestSharpAbility.cs
@@ -51,14 +51,26 @@ namespace Boa.Constrictor.RestSharp
         public IRestClient Client { get; protected set; }
 
         /// <summary>
-        /// The dumper for requests and responses.
-        /// </summary>
-        public JsonDumper RequestDumper { get; protected set; }
-
-        /// <summary>
         /// The dumper for downloaded files.
         /// </summary>
         public ByteDumper DownloadDumper { get; protected set; }
+
+        /// <summary>
+        /// The dumper for requests and responses.
+        /// </summary>
+        public RequestDumper RequestDumper { get; protected set; }
+
+        /// <summary>
+        /// The last request object dumped.
+        /// Warning: it might be null.
+        /// </summary>
+        public IRestRequest LastRequest => RequestDumper.LastRequest;
+
+        /// <summary>
+        /// The last response object dumped.
+        /// Warning: it might be null.
+        /// </summary>
+        public IRestResponse LastResponse => RequestDumper.LastResponse;
 
         #endregion
 

--- a/Boa.Constrictor/RestSharp/Abilities/CallRestApi.cs
+++ b/Boa.Constrictor/RestSharp/Abilities/CallRestApi.cs
@@ -48,7 +48,7 @@ namespace Boa.Constrictor.RestSharp
         /// <returns></returns>
         public CallRestApi DumpingRequestsTo(string dumpDir, string fileToken = "Request")
         {
-            RequestDumper = new JsonDumper("REST Request Dumper", dumpDir, fileToken);
+            RequestDumper = new RequestDumper("REST Request Dumper", dumpDir, fileToken);
             return this;
         }
 

--- a/Boa.Constrictor/RestSharp/Abilities/IRestSharpAbility.cs
+++ b/Boa.Constrictor/RestSharp/Abilities/IRestSharpAbility.cs
@@ -25,14 +25,26 @@ namespace Boa.Constrictor.RestSharp
         IRestClient Client { get; }
 
         /// <summary>
-        /// The dumper for requests and responses.
+        /// The dumper for downloaded files.
         /// </summary>
         ByteDumper DownloadDumper { get; }
 
         /// <summary>
-        /// The dumper for downloaded files.
+        /// The dumper for requests and responses.
         /// </summary>
-        JsonDumper RequestDumper { get; }
+        RequestDumper RequestDumper { get; }
+
+        /// <summary>
+        /// The last request object dumped.
+        /// Warning: it might be null.
+        /// </summary>
+        IRestRequest LastRequest { get; }
+
+        /// <summary>
+        /// The last response object dumped.
+        /// Warning: it might be null.
+        /// </summary>
+        IRestResponse LastResponse { get; }
 
         #endregion
 

--- a/Boa.Constrictor/RestSharp/Abilities/RequestDumper.cs
+++ b/Boa.Constrictor/RestSharp/Abilities/RequestDumper.cs
@@ -1,0 +1,68 @@
+﻿using Boa.Constrictor.Dumping;
+using RestSharp;
+using System;
+
+namespace Boa.Constrictor.RestSharp
+{
+    /// <summary>
+    /// Dumps RestSharp requests and responses.
+    /// </summary>
+    public class RequestDumper : JsonDumper
+    {
+        #region Properties
+
+        /// <summary>
+        /// The last request object dumped.
+        /// Warning: it might be null.
+        /// </summary>
+        public IRestRequest LastRequest { get; private set; } = null;
+
+        /// <summary>
+        /// The last response object dumped.
+        /// Warning: it might be null.
+        /// </summary>
+        public IRestResponse LastResponse { get; private set; } = null;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">A descriptive name for the dumper.</param>
+        /// <param name="dumpDir">The output directory for dumping requests and responses.</param>
+        /// <param name="fileToken">The token for the file name.</param>
+        public RequestDumper(string name, string dumpDir, string fileToken) :
+            base(name, dumpDir, fileToken) { }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Writes the JSON dump file to the dump directory for the request and the response.
+        /// Returns the dumped file's path.
+        /// </summary>
+        /// <param name="client">RestSharp client.</param>
+        /// <param name="request">Request object.</param>
+        /// <param name="response">Response object.</param>
+        /// <param name="start">Request's start time.</param>
+        /// <param name="end">Request's end time.</param>
+        /// <returns></returns>
+        public string Dump(
+            IRestClient client,
+            IRestRequest request = null,
+            IRestResponse response = null,
+            DateTime? start = null,
+            DateTime? end = null)
+        {
+            LastRequest = request;
+            LastResponse = response;
+
+            return Dump(new FullRestData(client, request, response, start, end));
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor/RestSharp/Interactions/AbstractRestQuestion.cs
+++ b/Boa.Constrictor/RestSharp/Interactions/AbstractRestQuestion.cs
@@ -129,8 +129,7 @@ namespace Boa.Constrictor.RestSharp
                 if (ability.CanDumpRequests())
                 {
                     // Try to dump the request and the response
-                    var data = new FullRestData(ability.Client, Request, response, start, end);
-                    string path = ability.RequestDumper.Dump(data);
+                    string path = ability.RequestDumper.Dump(ability.Client, Request, response, start, end);
                     actor.Logger.Info($"Dumped request to: {path}");
                 }
                 else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.6.1] - 2020-12-08
+
+### Added
+
+- Added the `RequestDumper` class to automatically store the last request and response objects
+- Added `LastRequest` and `LastResponse` properties to `IRestSharpAbility` to more conveniently access these values from the dumper
+
+### Changed
+
+- `IRestSharpAbility` now uses `RequestDumper` instead of `JsonDumper` to dump requests and responses
+
+
 ## [0.6.0] - 2020-12-02
 
 ### Changed


### PR DESCRIPTION
`LastRequest` and `LastResponse` store the previous request and response objects made by the client. It is captured and stored by the new `RequestDumper` class.

**This change includes a version update to 0.6.1!**