### PR TITLE
Added more concise waiting syntax

### DIFF
--- a/Boa.Constrictor.Example/Tests/DuckDuckGoTest.cs
+++ b/Boa.Constrictor.Example/Tests/DuckDuckGoTest.cs
@@ -30,7 +30,7 @@ namespace Boa.Constrictor.Example
             Actor.AttemptsTo(Navigate.ToUrl(SearchPage.Url));
             Actor.AskingFor(ValueAttribute.Of(SearchPage.SearchInput)).Should().BeEmpty();
             Actor.AttemptsTo(SearchDuckDuckGo.For("panda"));
-            Actor.AttemptsTo(Wait.Until(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True()));
+            Actor.WaitsUntil(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True());
         }
     }
 }

--- a/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitTest.cs
+++ b/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitTest.cs
@@ -14,7 +14,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
     {
         #region Test Variables
 
-        private IActor Screenplayer { get; set; }
+        private IActor Actor { get; set; }
         private Mock<IQuestion<int>> MockQuestion { get; set; }
         private Mock<ICondition<int>> MockCondition { get; set; }
 
@@ -25,7 +25,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
         [SetUp]
         public void SetUp()
         {
-            Screenplayer = new Actor();
+            Actor = new Actor();
             MockQuestion = new Mock<IQuestion<int>>();
             MockCondition = new Mock<ICondition<int>>();
         }
@@ -40,7 +40,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockQuestion.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
             MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(true);
 
-            Screenplayer.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
+            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
                 .Should().NotThrow(because: "the question should satisfy the condition");
         }
 
@@ -54,7 +54,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockCondition.Setup(x => x.Evaluate(It.Is<int>(v => v < limit))).Returns(false);
             MockCondition.Setup(x => x.Evaluate(It.Is<int>(v => v >= limit))).Returns(true);
 
-            Screenplayer.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(1)))
+            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(1)))
                 .Should().NotThrow(because: "the question should satisfy the condition");
 
             incrementer.Should().Be(limit, because: $"the question should be called {limit} times");
@@ -66,7 +66,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockQuestion.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
             MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
 
-            Screenplayer.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
+            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
                 .Should().Throw<WaitingException<int>>(because: "the question should not satisfy the condition");
         }
 

--- a/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitingExtensionsTest.cs
+++ b/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitingExtensionsTest.cs
@@ -6,11 +6,11 @@ using NUnit.Framework;
 namespace Boa.Constrictor.UnitTests.Screenplay
 {
     /// <summary>
-    /// These tests for the ValueAfterWaiting question are very rudimentary.
+    /// These tests for WaitingExtensions are very rudimentary.
     /// They simply verify if exceptions are thrown when questions do and do not satisfy the condition for waiting.
     /// </summary>
     [TestFixture]
-    public class ValueAfterWaitingTest
+    public class WaitingExtensionsTest
     {
         #region Test Variables
 
@@ -40,7 +40,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockQuestion.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
             MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(true);
 
-            Actor.AskingFor(ValueAfterWaiting.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0))
+            Actor.WaitsUntil(MockQuestion.Object, MockCondition.Object, timeout: 0)
                 .Should().Be(1, because: "waiting should return the question's final answer");
         }
 
@@ -54,7 +54,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockCondition.Setup(x => x.Evaluate(It.Is<int>(v => v < limit))).Returns(false);
             MockCondition.Setup(x => x.Evaluate(It.Is<int>(v => v >= limit))).Returns(true);
 
-            Actor.AskingFor(ValueAfterWaiting.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(1))
+            Actor.WaitsUntil(MockQuestion.Object, MockCondition.Object, timeout: 1)
                 .Should().Be(limit, because: "waiting should return the question's final answer");
 
             incrementer.Should().Be(limit, because: $"the question should be called {limit} times");
@@ -66,7 +66,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockQuestion.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
             MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
 
-            Actor.Invoking(actor => actor.AskingFor(ValueAfterWaiting.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
+            Actor.Invoking(actor => actor.WaitsUntil(MockQuestion.Object, MockCondition.Object, timeout: 0))
                 .Should().Throw<WaitingException<int>>(because: "the question should not satisfy the condition");
         }
 

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.6.1</Version>
+    <Version>0.7.0</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/Screenplay/Waiting/AbstractWait.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/AbstractWait.cs
@@ -11,8 +11,8 @@ namespace Boa.Constrictor.Screenplay
     /// If the actor has the SetTimeouts ability, then the ability will be used to calculate timeouts.
     /// Otherwise, DefaultTimeout will be used.
     /// </summary>
-    /// <typeparam name="TValue">The type of the question's answer value.</typeparam>
-    public abstract class AbstractWait<TValue>
+    /// <typeparam name="TAnswer">The type of the question's answer value.</typeparam>
+    public abstract class AbstractWait<TAnswer>
     {
         #region Constants
 
@@ -33,7 +33,7 @@ namespace Boa.Constrictor.Screenplay
         /// </summary>
         /// <param name="question">The question upon whose answer to wait.</param>
         /// <param name="condition">The expected condition for which to wait.</param>
-        protected AbstractWait(IQuestion<TValue> question, ICondition<TValue> condition)
+        protected AbstractWait(IQuestion<TAnswer> question, ICondition<TAnswer> condition)
         {
             Question = question;
             Condition = condition;
@@ -50,12 +50,12 @@ namespace Boa.Constrictor.Screenplay
         /// <summary>
         /// The expected condition for which to wait.
         /// </summary>
-        public ICondition<TValue> Condition { get; protected set; }
+        public ICondition<TAnswer> Condition { get; protected set; }
 
         /// <summary>
         /// The question upon whose answer to wait.
         /// </summary>
-        public IQuestion<TValue> Question { get; protected set; }
+        public IQuestion<TAnswer> Question { get; protected set; }
 
         /// <summary>
         /// The timeout override in seconds.
@@ -105,10 +105,10 @@ namespace Boa.Constrictor.Screenplay
         /// </summary>
         /// <param name="actor">The actor.</param>
         /// <returns></returns>
-        protected TValue WaitForValue(IActor actor)
+        protected TAnswer WaitForValue(IActor actor)
         {
             // Set variables
-            TValue actual = default(TValue);
+            TAnswer actual = default(TAnswer);
             bool satisfied = false;
             ActualTimeout = CalculateTimeout(actor);
 
@@ -143,7 +143,7 @@ namespace Boa.Constrictor.Screenplay
 
             // Verify successful waiting
             if (!satisfied)
-                throw new WaitingException<TValue>(this, actual);
+                throw new WaitingException<TAnswer>(this, actual);
 
             // Return the actual awaited value
             return actual;

--- a/Boa.Constrictor/Screenplay/Waiting/ValueAfterWaiting.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/ValueAfterWaiting.cs
@@ -8,8 +8,8 @@
     /// If the actor has the SetTimeouts ability, then the ability will be used to calculate timeouts.
     /// Otherwise, DefaultTimeout will be used.
     /// </summary>
-    /// <typeparam name="TValue">The type of the question's answer value.</typeparam>
-    public class ValueAfterWaiting<TValue> : AbstractWait<TValue>, IQuestion<TValue>
+    /// <typeparam name="TAnswer">The type of the question's answer value.</typeparam>
+    public class ValueAfterWaiting<TAnswer> : AbstractWait<TAnswer>, IQuestion<TAnswer>
     {
         #region Constructors
 
@@ -19,7 +19,7 @@
         /// </summary>
         /// <param name="question">The question upon whose answer to wait.</param>
         /// <param name="condition">The expected condition for which to wait.</param>
-        private ValueAfterWaiting(IQuestion<TValue> question, ICondition<TValue> condition) :
+        private ValueAfterWaiting(IQuestion<TAnswer> question, ICondition<TAnswer> condition) :
             base(question, condition)
         { }
 
@@ -33,15 +33,15 @@
         /// <param name="question">The question upon whose answer to wait.</param>
         /// <param name="condition">The expected condition for which to wait.</param>
         /// <returns></returns>
-        public static ValueAfterWaiting<TValue> Until(IQuestion<TValue> question, ICondition<TValue> condition) =>
-            new ValueAfterWaiting<TValue>(question, condition);
+        public static ValueAfterWaiting<TAnswer> Until(IQuestion<TAnswer> question, ICondition<TAnswer> condition) =>
+            new ValueAfterWaiting<TAnswer>(question, condition);
 
         /// <summary>
         /// Sets an override value for timeout seconds.
         /// </summary>
         /// <param name="seconds">The new timeout in seconds.</param>
         /// <returns></returns>
-        public ValueAfterWaiting<TValue> ForUpTo(int? seconds)
+        public ValueAfterWaiting<TAnswer> ForUpTo(int? seconds)
         {
             TimeoutSeconds = seconds;
             return this;
@@ -52,7 +52,7 @@
         /// </summary>
         /// <param name="seconds">The seconds to add to the timeout.</param>
         /// <returns></returns>
-        public ValueAfterWaiting<TValue> ForAnAdditional(int seconds)
+        public ValueAfterWaiting<TAnswer> ForAnAdditional(int seconds)
         {
             AdditionalSeconds = seconds;
             return this;
@@ -64,7 +64,7 @@
         /// This may generate lots of spam.
         /// </summary>
         /// <returns></returns>
-        public ValueAfterWaiting<TValue> ButDontSuppressLogs()
+        public ValueAfterWaiting<TAnswer> ButDontSuppressLogs()
         {
             SuppressLogs = false;
             return this;
@@ -81,7 +81,7 @@
         /// </summary>
         /// <param name="actor">The actor.</param>
         /// <returns></returns>
-        public TValue RequestAs(IActor actor) => WaitForValue(actor);
+        public TAnswer RequestAs(IActor actor) => WaitForValue(actor);
 
         #endregion
     }

--- a/Boa.Constrictor/Screenplay/Waiting/Wait.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/Wait.cs
@@ -8,8 +8,8 @@
     /// If the actor has the SetTimeouts ability, then the ability will be used to calculate timeouts.
     /// Otherwise, DefaultTimeout will be used.
     /// </summary>
-    /// <typeparam name="TValue">The type of the question's answer value.</typeparam>
-    public class Wait<TValue> : AbstractWait<TValue>, ITask
+    /// <typeparam name="TAnswer">The type of the question's answer value.</typeparam>
+    public class Wait<TAnswer> : AbstractWait<TAnswer>, ITask
     {
         #region Constructors
 
@@ -19,7 +19,7 @@
         /// </summary>
         /// <param name="question">The question upon whose answer to wait.</param>
         /// <param name="condition">The expected condition for which to wait.</param>
-        private Wait(IQuestion<TValue> question, ICondition<TValue> condition) :
+        private Wait(IQuestion<TAnswer> question, ICondition<TAnswer> condition) :
             base(question, condition)
         { }
 
@@ -33,15 +33,15 @@
         /// <param name="question">The question upon whose answer to wait.</param>
         /// <param name="condition">The expected condition for which to wait.</param>
         /// <returns></returns>
-        public static Wait<TValue> Until(IQuestion<TValue> question, ICondition<TValue> condition) =>
-            new Wait<TValue>(question, condition);
+        public static Wait<TAnswer> Until(IQuestion<TAnswer> question, ICondition<TAnswer> condition) =>
+            new Wait<TAnswer>(question, condition);
 
         /// <summary>
         /// Sets an override value for timeout seconds.
         /// </summary>
         /// <param name="seconds">The new timeout in seconds.</param>
         /// <returns></returns>
-        public Wait<TValue> ForUpTo(int? seconds)
+        public Wait<TAnswer> ForUpTo(int? seconds)
         {
             TimeoutSeconds = seconds;
             return this;
@@ -52,7 +52,7 @@
         /// </summary>
         /// <param name="seconds">The seconds to add to the timeout.</param>
         /// <returns></returns>
-        public Wait<TValue> ForAnAdditional(int seconds)
+        public Wait<TAnswer> ForAnAdditional(int seconds)
         {
             AdditionalSeconds = seconds;
             return this;
@@ -64,7 +64,7 @@
         /// This may generate lots of spam.
         /// </summary>
         /// <returns></returns>
-        public Wait<TValue> ButDontSuppressLogs()
+        public Wait<TAnswer> ButDontSuppressLogs()
         {
             SuppressLogs = false;
             return this;

--- a/Boa.Constrictor/Screenplay/Waiting/WaitingException.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/WaitingException.cs
@@ -4,8 +4,8 @@
     /// This exception should be thrown when the Wait interaction fails to meet its expected condition.
     /// It provides attributes for the actual value, the question, and the condition.
     /// </summary>
-    /// <typeparam name="TValue"></typeparam>
-    public class WaitingException<TValue> : ScreenplayException
+    /// <typeparam name="TAnswer">The type of the question's answer value.</typeparam>
+    public class WaitingException<TAnswer> : ScreenplayException
     {
         #region Constructors
 
@@ -15,7 +15,7 @@
         /// <param name="message">The exception message.</param>
         /// <param name="interaction">The waiting interaction.</param>
         /// <param name="actual">The actual value received after waiting.</param>
-        private WaitingException(string message, AbstractWait<TValue> interaction, TValue actual) :
+        private WaitingException(string message, AbstractWait<TAnswer> interaction, TAnswer actual) :
             base(message)
         {
             Interaction = interaction;
@@ -27,7 +27,7 @@
         /// </summary>
         /// <param name="interaction">The waiting interaction.</param>
         /// <param name="actual">The actual value received after waiting.</param>
-        public WaitingException(AbstractWait<TValue> interaction, TValue actual) :
+        public WaitingException(AbstractWait<TAnswer> interaction, TAnswer actual) :
             this($"{interaction} timed out yielding '{actual}'", interaction, actual)
         { }
 
@@ -38,12 +38,12 @@
         /// <summary>
         /// The actual value received after waiting.
         /// </summary>
-        public TValue ActualValue { get; }
+        public TAnswer ActualValue { get; }
 
         /// <summary>
         /// The waiting interaction.
         /// </summary>
-        public AbstractWait<TValue> Interaction { get; }
+        public AbstractWait<TAnswer> Interaction { get; }
 
         #endregion
     }

--- a/Boa.Constrictor/Screenplay/Waiting/WaitingExtensions.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/WaitingExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace Boa.Constrictor.Screenplay
+{
+    /// <summary>
+    /// Provides IActor extension methods to simplify waiting syntax.
+    /// 
+    /// </summary>
+    public static class WaitingExtensions
+    {
+        /// <summary>
+        /// A simplified extension method for waiting.
+        /// Calls will look like `Actor.WaitsUntil(...)` instead of `Actor.AsksFor(ValueAfterWaiting.Until(...))`.
+        /// </summary>
+        /// <typeparam name="TAnswer">The type of the question's answer value.</typeparam>
+        /// <param name="actor">The Screenplay actor.</param>
+        /// <param name="question">The question upon whose answer to wait.</param>
+        /// <param name="condition">The expected condition for which to wait.</param>
+        /// <param name="timeout">The timeout override in seconds. If null, use the standard timeout value.</param>
+        /// <param name="additional">An additional amount to add to the timeout. Defaults to 0.</param>
+        /// <returns></returns>
+        public static TAnswer WaitsUntil<TAnswer>(
+            this IActor actor,
+            IQuestion<TAnswer> question,
+            ICondition<TAnswer> condition,
+            int? timeout = null,
+            int additional = 0) =>
+
+            actor.AsksFor(ValueAfterWaiting.Until(question, condition).ForUpTo(timeout).ForAnAdditional(additional));
+    }
+}

--- a/Boa.Constrictor/WebDriver/Questions/BrowserCookie.cs
+++ b/Boa.Constrictor/WebDriver/Questions/BrowserCookie.cs
@@ -56,7 +56,7 @@ namespace Boa.Constrictor.WebDriver
             try
             {
                 // Wait for the cookie to exist
-                actor.AttemptsTo(Wait.Until(BrowserCookieExistence.Named(CookieName), IsEqualTo.True()));
+                actor.WaitsUntil(BrowserCookieExistence.Named(CookieName), IsEqualTo.True());
             }
             catch (WaitingException<bool> e)
             {

--- a/Boa.Constrictor/WebDriver/Questions/Classes.cs
+++ b/Boa.Constrictor/WebDriver/Questions/Classes.cs
@@ -40,7 +40,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string[] RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             string classes = driver.FindElement(Locator.Query).GetAttribute("class");
             return classes.Split();
         }

--- a/Boa.Constrictor/WebDriver/Questions/CssValue.cs
+++ b/Boa.Constrictor/WebDriver/Questions/CssValue.cs
@@ -43,7 +43,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).GetCssValue(PropertyName);
         }
         

--- a/Boa.Constrictor/WebDriver/Questions/EnabledState.cs
+++ b/Boa.Constrictor/WebDriver/Questions/EnabledState.cs
@@ -40,7 +40,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override bool RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).Enabled;
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/HtmlAttribute.cs
+++ b/Boa.Constrictor/WebDriver/Questions/HtmlAttribute.cs
@@ -42,7 +42,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).GetAttribute(PropertyName);
         }
         

--- a/Boa.Constrictor/WebDriver/Questions/JavaScript.cs
+++ b/Boa.Constrictor/WebDriver/Questions/JavaScript.cs
@@ -85,7 +85,7 @@ namespace Boa.Constrictor.WebDriver
             // If a locator is given, get the element and make it the first argument
             if (Locator != null)
             {
-                actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+                actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
                 var e = driver.FindElement(Locator.Query);
 
                 IList<object> tempList = Args.ToList();

--- a/Boa.Constrictor/WebDriver/Questions/JavaScriptProperty.cs
+++ b/Boa.Constrictor/WebDriver/Questions/JavaScriptProperty.cs
@@ -42,7 +42,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).GetProperty(PropertyName);
         }
         

--- a/Boa.Constrictor/WebDriver/Questions/Location.cs
+++ b/Boa.Constrictor/WebDriver/Questions/Location.cs
@@ -41,7 +41,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override Point RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).Location;
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/PixelSize.cs
+++ b/Boa.Constrictor/WebDriver/Questions/PixelSize.cs
@@ -41,7 +41,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override Size RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).Size;
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/SelectOptionsAvailable.cs
+++ b/Boa.Constrictor/WebDriver/Questions/SelectOptionsAvailable.cs
@@ -43,7 +43,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override IList<string> RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return new SelectElement(driver.FindElement(Locator.Query)).Options.Select(o => o.Text).ToList();
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/SelectedOptionText.cs
+++ b/Boa.Constrictor/WebDriver/Questions/SelectedOptionText.cs
@@ -41,7 +41,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return new SelectElement(driver.FindElement(Locator.Query)).SelectedOption.Text;
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/SelectedState.cs
+++ b/Boa.Constrictor/WebDriver/Questions/SelectedState.cs
@@ -40,7 +40,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override bool RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).Selected;
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/TagName.cs
+++ b/Boa.Constrictor/WebDriver/Questions/TagName.cs
@@ -40,7 +40,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).TagName;
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/Text.cs
+++ b/Boa.Constrictor/WebDriver/Questions/Text.cs
@@ -40,7 +40,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             return driver.FindElement(Locator.Query).Text;
         }
 

--- a/Boa.Constrictor/WebDriver/Questions/TextList.cs
+++ b/Boa.Constrictor/WebDriver/Questions/TextList.cs
@@ -42,7 +42,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override IEnumerable<string> RequestAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             var elements = driver.FindElements(Locator.Query);
             var strings = from e in elements select e.Text;
 

--- a/Boa.Constrictor/WebDriver/Tasks/Clear.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Clear.cs
@@ -39,7 +39,7 @@ namespace Boa.Constrictor.WebDriver
         /// <param name="driver">The WebDriver.</param>
         public override void PerformAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Appearance.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Appearance.Of(Locator), IsEqualTo.True());
             driver.FindElement(Locator.Query).Clear();
         }
 

--- a/Boa.Constrictor/WebDriver/Tasks/Click.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Click.cs
@@ -41,7 +41,7 @@ namespace Boa.Constrictor.WebDriver
         /// <param name="driver">The WebDriver.</param>
         public override void PerformAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Appearance.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Appearance.Of(Locator), IsEqualTo.True());
             new Actions(driver).MoveToElement(driver.FindElement(Locator.Query)).Click().Perform();
         }
 

--- a/Boa.Constrictor/WebDriver/Tasks/Hover.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Hover.cs
@@ -41,7 +41,7 @@ namespace Boa.Constrictor.WebDriver
         /// <param name="driver">The WebDriver.</param>
         public override void PerformAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Appearance.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Appearance.Of(Locator), IsEqualTo.True());
             new Actions(driver).MoveToElement(driver.FindElement(Locator.Query)).Perform();
         }
 

--- a/Boa.Constrictor/WebDriver/Tasks/Select.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Select.cs
@@ -100,7 +100,7 @@ namespace Boa.Constrictor.WebDriver
         /// <param name="driver">The WebDriver.</param>
         public override void PerformAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
 
             var select = new SelectElement(driver.FindElement(Locator.Query));
 

--- a/Boa.Constrictor/WebDriver/Tasks/SendKeys.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/SendKeys.cs
@@ -150,7 +150,7 @@ namespace Boa.Constrictor.WebDriver
         public override void PerformAs(IActor actor, IWebDriver driver)
         {
             // Wait for the element to exist
-            actor.AttemptsTo(Wait.Until(Appearance.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Appearance.Of(Locator), IsEqualTo.True());
 
             // Get the element
             IWebElement element = driver.FindElement(Locator.Query);

--- a/Boa.Constrictor/WebDriver/Tasks/Submit.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Submit.cs
@@ -43,7 +43,7 @@ namespace Boa.Constrictor.WebDriver
         /// <param name="driver">The WebDriver.</param>
         public override void PerformAs(IActor actor, IWebDriver driver)
         {
-            actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+            actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
             driver.FindElement(Locator.Query).Submit();
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.7.0] - 2020-12-22
+
+### Added
+
+- Added `WaitsUntil` extension method to `IActor` for more concise waiting calls
+- Updated all interactions and the tutorial to use `WaitsUntil`
+
+
 ## [0.6.1] - 2020-12-08
 
 ### Added

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -661,14 +661,16 @@ Let's break it down:
 * `Actor.WaitsUntil(...)` is an extension method that halts execution until the given Question's answer meets the given Condition.
   In this case, the appearance of the result links must become true.
 
-`WaitsUntil` is an `IActor` extension method that calls waiting interactions.
-Internally, it makes a call like this:
+`WaitsUntil` is an `IActor` extension method that internally calls waiting interactions.
+The following calls are essentially the same:
 
 ```csharp
+// The full, "traditional" way to wait
 actor.AttemptsTo(Wait.Until(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True()));
-```
 
-Both calls do the same thing, but `WaitsUntil` is more concise.
+// The more concise way using
+actor.WaitsUntil(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True());
+```
 
 There are two waiting interactions under the `Boa.Constrictor.Screenplay` namespace:
 a Task named `Wait` and a Question named `ValueAfterWaiting`.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -492,7 +492,7 @@ public class ValueAttribute : IQuestion<string>
     public string RequestAs(IActor actor)
     {
         var driver = actor.Using<BrowseTheWeb>().WebDriver;
-        actor.AttemptsTo(Wait.Until(Existence.Of(Locator), IsEqualTo.True()));
+        actor.WaitsUntil(Existence.Of(Locator), IsEqualTo.True());
         return driver.FindElement(Locator.Query).GetAttribute("value");
     }
 }
@@ -647,28 +647,37 @@ This locator will find all result links on the result page.
 Then, add the following line to `TestDuckDuckGoSearch`:
 
 ```csharp
-actor.AttemptsTo(Wait.Until(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True()));
+actor.WaitsUntil(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True());
 ```
 
 Read this line in plain English:
-"The actor attempts to wait until the appearance of result page result links is equal to true."
+"The actor waits until the appearance of result page result links is equal to true."
 In simpler terms, "Wait until the result links appear."
 Let's break it down:
 
 * `ResultPage.ResultLinks` is the locator for the result link elements.
 * `Appearance.Of(...)` is a Question that returns true if the target elements are currently displayed on the page.
 * `IsEqualTo.True()` is a *Condition* for checking if the return value of a Question is true.
-* `Wait.Until(...)` is a Task that halts execution until the given Question's answer meets the given Condition.
+* `Actor.WaitsUntil(...)` is an extension method that halts execution until the given Question's answer meets the given Condition.
   In this case, the appearance of the result links must become true.
 
-The `Wait` Task is located under the `Boa.Constrictor.Screenplay` namespace.
-It works for any type of Question, not just WebDriver-based Questions.
+`WaitsUntil` is an `IActor` extension method that calls waiting interactions.
+Internally, it makes a call like this:
+
+```csharp
+actor.AttemptsTo(Wait.Until(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True()));
+```
+
+Both calls do the same thing, but `WaitsUntil` is more concise.
+
+There are two waiting interactions under the `Boa.Constrictor.Screenplay` namespace:
+a Task named `Wait` and a Question named `ValueAfterWaiting`.
+Both waiting interactions work for any type of Question, not just WebDriver-based Questions.
 If the given Question fails to meet the given Condition within a timeout limit,
-then `Wait` throws a `WaitingException`.
+then waiting throws a `WaitingException`.
 The default timeout is 30 seconds, but it may be overridden like this:
-`Wait.Until(...).ForUpTo(60)'`.
-There is also a waiting Question named `ValueAfterWaiting` that works the same way as `Wait`
-except that it returns the final answer from the given Question.
+`WaitsUntil(..., timeout: 60)`,
+or like this: `Wait.Until(...).ForUpTo(60)`.
 
 Waiting also requires Conditions.
 A *Condition* is a required state for a value.
@@ -761,7 +770,7 @@ namespace Boa.Constrictor.Example
             Actor.AttemptsTo(Navigate.ToUrl(SearchPage.Url));
             Actor.AskingFor(ValueAttribute.Of(SearchPage.SearchInput)).Should().BeEmpty();
             Actor.AttemptsTo(SearchDuckDuckGo.For("panda"));
-            Actor.AttemptsTo(Wait.Until(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True()));
+            Actor.WaitsUntil(Appearance.Of(ResultPage.ResultLinks), IsEqualTo.True());
         }
     }
 }


### PR DESCRIPTION
Old waiting calls:
`Actor.AttemptsTo(Wait.Until(...));`

New waiting calls:
`Actor.WaitsUntil(...);`

`WaitsUntil` is an `IActor` extension method. Using extension methods to improve syntax follows the spirit of SOLID principles. We may use this pattern in the future for other interactions, especially when interactions call other interactions.

**This change updates Boa Constrictor to 0.7.0!**