### PR TITLE
Added TestLogger

### DIFF
--- a/Boa.Constrictor.UnitTests/Logging/Loggers/ConsoleLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/ConsoleLoggerTest.cs
@@ -61,11 +61,19 @@ namespace Boa.Constrictor.UnitTests.Logging
         [Test]
         public void Close()
         {
-            using (var output = new ConsoleOutput())
-            {
-                Logger.Close();
-                output.GetOutput().Trim().Should().Be("");
-            }
+            using var output = new ConsoleOutput();
+            Logger.Close();
+            output.GetOutput().Trim().Should().Be("");
+        }
+
+        [Test]
+        public void LogArtifact()
+        {
+            using var output = new ConsoleOutput();
+            const string type = "Screenshot";
+            const string path = "path/to/screen.png";
+            Logger.LogArtifact(type, path);
+            output.GetOutput().Trim().Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[INFO] {type}: {path}");
         }
 
         [TestCase("Trace")]
@@ -76,12 +84,10 @@ namespace Boa.Constrictor.UnitTests.Logging
         [TestCase("Fatal")]
         public void LogByLevel(string level)
         {
-            using (var output = new ConsoleOutput())
-            {
-                const string message = "Message text!";
-                Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
-                output.GetOutput().Trim().Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[{level.ToUpper()}] {message}");
-            }
+            using var output = new ConsoleOutput();
+            const string message = "Message text!";
+            Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
+            output.GetOutput().Trim().Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[{level.ToUpper()}] {message}");
         }
 
         [TestCase("Info")]
@@ -90,13 +96,11 @@ namespace Boa.Constrictor.UnitTests.Logging
         [TestCase("Fatal")]
         public void LowestSeverityLogged(string level)
         {
-            using (var output = new ConsoleOutput())
-            {
-                const string message = "Message text!";
-                Logger.LowestSeverity = LogSeverity.Info;
-                Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
-                output.GetOutput().Trim().Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[{level.ToUpper()}] {message}");
-            }
+            using var output = new ConsoleOutput();
+            const string message = "Message text!";
+            Logger.LowestSeverity = LogSeverity.Info;
+            Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
+            output.GetOutput().Trim().Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[{level.ToUpper()}] {message}");
         }
 
         [TestCase("Trace")]
@@ -106,13 +110,11 @@ namespace Boa.Constrictor.UnitTests.Logging
         [TestCase("Error")]
         public void LowestSeverityBlocked(string level)
         {
-            using (var output = new ConsoleOutput())
-            {
-                const string message = "Message text!";
-                Logger.LowestSeverity = LogSeverity.Fatal;
-                Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
-                output.GetOutput().Trim().Should().BeEmpty();
-            }
+            using var output = new ConsoleOutput();
+            const string message = "Message text!";
+            Logger.LowestSeverity = LogSeverity.Fatal;
+            Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
+            output.GetOutput().Trim().Should().BeEmpty();
         }
 
         #endregion

--- a/Boa.Constrictor.UnitTests/Logging/Loggers/ListLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/ListLoggerTest.cs
@@ -40,6 +40,16 @@ namespace Boa.Constrictor.UnitTests.Logging
             Logger.Messages.Count.Should().Be(2);
         }
 
+        [Test]
+        public void LogArtifact()
+        {
+            const string type = "Screenshot";
+            const string path = "path/to/screen.png";
+            Logger.LogArtifact(type, path);
+            Logger.Messages.Count.Should().Be(1);
+            Logger.Messages[0].Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[INFO] {type}: {path}");
+        }
+
         [TestCase("Trace")]
         [TestCase("Debug")]
         [TestCase("Info")]

--- a/Boa.Constrictor.UnitTests/Logging/Loggers/NoOpLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/NoOpLoggerTest.cs
@@ -33,6 +33,13 @@ namespace Boa.Constrictor.UnitTests.Logging
             Logger.Invoking(y => y.Close()).Should().NotThrow();
         }
 
+        [Test]
+        public void LogArtifact()
+        {
+            Logger.LogArtifact("Screenshot", "path/to/screen.png");
+            Logger.Invoking(y => y.Close()).Should().NotThrow();
+        }
+
         [TestCase("Trace")]
         [TestCase("Debug")]
         [TestCase("Info")]

--- a/Boa.Constrictor.UnitTests/Logging/Loggers/TeeLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/TeeLoggerTest.cs
@@ -131,6 +131,21 @@ namespace Boa.Constrictor.UnitTests.Logging
                 }
             }
 
+            [Test]
+            public void LogArtifact()
+            {
+                const string type = "Screenshot";
+                const string path = "path/to/screen.png";
+                Logger.LogArtifact(type, path);
+
+                for (int i = 1; i <= LoggerCount; i++)
+                {
+                    ListLogger lister = (ListLogger)Logger.Get(i.ToString());
+                    lister.Messages.Count.Should().Be(1);
+                    lister.Messages[0].Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[INFO] {type}: {path}");
+                }
+            }
+
             [TestCase("Trace")]
             [TestCase("Debug")]
             [TestCase("Info")]

--- a/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
@@ -78,13 +78,13 @@ namespace Boa.Constrictor.UnitTests.Logging
         public void DumpTestLogWithArtifacts()
         {
             Logger.LogStep("A");
-            Logger.LogArtifact(ArtifactTypes.Screenshot, "a1.png");
-            Logger.LogArtifact(ArtifactTypes.Screenshot, "a2.png");
-            Logger.LogArtifact(ArtifactTypes.Download, "downA.pdf");
+            Logger.LogArtifact(ArtifactTypes.Screenshots, "a1.png");
+            Logger.LogArtifact(ArtifactTypes.Screenshots, "a2.png");
+            Logger.LogArtifact(ArtifactTypes.Downloads, "downA.pdf");
             Logger.LogStep("B");
-            Logger.LogArtifact(ArtifactTypes.Screenshot, "b.png");
-            Logger.LogArtifact(ArtifactTypes.Download, "downB1.pdf");
-            Logger.LogArtifact(ArtifactTypes.Download, "downB2.pdf");
+            Logger.LogArtifact(ArtifactTypes.Screenshots, "b.png");
+            Logger.LogArtifact(ArtifactTypes.Downloads, "downB1.pdf");
+            Logger.LogArtifact(ArtifactTypes.Downloads, "downB2.pdf");
             Logger.Close();
 
             using var file = new StreamReader(Logger.TestLogPath);
@@ -99,11 +99,11 @@ namespace Boa.Constrictor.UnitTests.Logging
             data.Steps[0].Messages[1].Should().EndWith("Screenshot: a2.png");
             data.Steps[0].Messages[2].Should().EndWith("Download: downA.pdf");
             data.Steps[0].Artifacts.Count.Should().Be(2);
-            data.Steps[0].Artifacts[ArtifactTypes.Screenshot].Count.Should().Be(2);
-            data.Steps[0].Artifacts[ArtifactTypes.Screenshot][0].Should().Be("a1.png");
-            data.Steps[0].Artifacts[ArtifactTypes.Screenshot][1].Should().Be("a2.png");
-            data.Steps[0].Artifacts[ArtifactTypes.Download].Count.Should().Be(1);
-            data.Steps[0].Artifacts[ArtifactTypes.Download][0].Should().Be("downA.pdf");
+            data.Steps[0].Artifacts[ArtifactTypes.Screenshots].Count.Should().Be(2);
+            data.Steps[0].Artifacts[ArtifactTypes.Screenshots][0].Should().Be("a1.png");
+            data.Steps[0].Artifacts[ArtifactTypes.Screenshots][1].Should().Be("a2.png");
+            data.Steps[0].Artifacts[ArtifactTypes.Downloads].Count.Should().Be(1);
+            data.Steps[0].Artifacts[ArtifactTypes.Downloads][0].Should().Be("downA.pdf");
 
             data.Steps[1].Name.Should().Be("B");
             data.Steps[1].Messages.Count.Should().Be(3);
@@ -111,11 +111,11 @@ namespace Boa.Constrictor.UnitTests.Logging
             data.Steps[1].Messages[1].Should().EndWith("Download: downB1.pdf");
             data.Steps[1].Messages[2].Should().EndWith("Download: downB2.pdf");
             data.Steps[1].Artifacts.Count.Should().Be(2);
-            data.Steps[1].Artifacts[ArtifactTypes.Screenshot].Count.Should().Be(1);
-            data.Steps[1].Artifacts[ArtifactTypes.Screenshot][0].Should().Be("b.png");
-            data.Steps[1].Artifacts[ArtifactTypes.Download].Count.Should().Be(2);
-            data.Steps[1].Artifacts[ArtifactTypes.Download][0].Should().Be("downB1.pdf");
-            data.Steps[1].Artifacts[ArtifactTypes.Download][1].Should().Be("downB2.pdf");
+            data.Steps[1].Artifacts[ArtifactTypes.Screenshots].Count.Should().Be(1);
+            data.Steps[1].Artifacts[ArtifactTypes.Screenshots][0].Should().Be("b.png");
+            data.Steps[1].Artifacts[ArtifactTypes.Downloads].Count.Should().Be(2);
+            data.Steps[1].Artifacts[ArtifactTypes.Downloads][0].Should().Be("downB1.pdf");
+            data.Steps[1].Artifacts[ArtifactTypes.Downloads][1].Should().Be("downB2.pdf");
         }
 
         #endregion

--- a/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
@@ -95,9 +95,9 @@ namespace Boa.Constrictor.UnitTests.Logging
 
             data.Steps[0].Name.Should().Be("A");
             data.Steps[0].Messages.Count.Should().Be(3);
-            data.Steps[0].Messages[0].Should().EndWith("Screenshot: a1.png");
-            data.Steps[0].Messages[1].Should().EndWith("Screenshot: a2.png");
-            data.Steps[0].Messages[2].Should().EndWith("Download: downA.pdf");
+            data.Steps[0].Messages[0].Should().EndWith("Screenshots: a1.png");
+            data.Steps[0].Messages[1].Should().EndWith("Screenshots: a2.png");
+            data.Steps[0].Messages[2].Should().EndWith("Downloads: downA.pdf");
             data.Steps[0].Artifacts.Count.Should().Be(2);
             data.Steps[0].Artifacts[ArtifactTypes.Screenshots].Count.Should().Be(2);
             data.Steps[0].Artifacts[ArtifactTypes.Screenshots][0].Should().Be("a1.png");
@@ -107,9 +107,9 @@ namespace Boa.Constrictor.UnitTests.Logging
 
             data.Steps[1].Name.Should().Be("B");
             data.Steps[1].Messages.Count.Should().Be(3);
-            data.Steps[1].Messages[0].Should().EndWith("Screenshot: b.png");
-            data.Steps[1].Messages[1].Should().EndWith("Download: downB1.pdf");
-            data.Steps[1].Messages[2].Should().EndWith("Download: downB2.pdf");
+            data.Steps[1].Messages[0].Should().EndWith("Screenshots: b.png");
+            data.Steps[1].Messages[1].Should().EndWith("Downloads: downB1.pdf");
+            data.Steps[1].Messages[2].Should().EndWith("Downloads: downB2.pdf");
             data.Steps[1].Artifacts.Count.Should().Be(2);
             data.Steps[1].Artifacts[ArtifactTypes.Screenshots].Count.Should().Be(1);
             data.Steps[1].Artifacts[ArtifactTypes.Screenshots][0].Should().Be("b.png");

--- a/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
@@ -1,0 +1,79 @@
+﻿using Boa.Constrictor.Logging;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System.IO;
+using System.Reflection;
+
+namespace Boa.Constrictor.UnitTests.Logging
+{
+    [TestFixture]
+    public class TestLoggerTest
+    {
+        #region Variables
+
+        private TestLogger Logger;
+
+        #endregion
+
+        #region Setup and Teardown
+
+        [SetUp]
+        public void SetUp()
+        {
+            string dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            Logger = new TestLogger("Unit Test", dir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(Logger.TestLogPath))
+                File.Delete(Logger.TestLogPath);
+        }
+
+        #endregion
+
+        #region Tests
+
+        [Test]
+        public void DumpEmptyTestLog()
+        {
+            Logger.Close();
+
+            using var file = new StreamReader(Logger.TestLogPath);
+            var data = JsonConvert.DeserializeObject<TestLogData>(file.ReadToEnd());
+
+            data.Name.Should().Be("Unit Test");
+            data.Steps.Should().BeEmpty();
+        }
+
+        [Test]
+        public void DumpTestLogWithMessages()
+        {
+            Logger.LogStep("A");
+            Logger.Info("Hello");
+            Logger.Warning("Oh no!");
+            Logger.Error("ERROR");
+            Logger.LogStep("B");
+            Logger.Debug("Here's a secret");
+            Logger.Close();
+
+            using var file = new StreamReader(Logger.TestLogPath);
+            var data = JsonConvert.DeserializeObject<TestLogData>(file.ReadToEnd());
+
+            data.Name.Should().Be("Unit Test");
+            data.Steps.Count.Should().Be(2);
+            data.Steps[0].Name.Should().Be("A");
+            data.Steps[0].Messages.Count.Should().Be(3);
+            data.Steps[0].Messages[0].Should().Contain("Hello");
+            data.Steps[0].Messages[1].Should().Contain("Oh no!");
+            data.Steps[0].Messages[2].Should().Contain("ERROR");
+            data.Steps[1].Name.Should().Be("B");
+            data.Steps[1].Messages.Count.Should().Be(1);
+            data.Steps[1].Messages[0].Should().Contain("Here's a secret");
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
@@ -74,6 +74,50 @@ namespace Boa.Constrictor.UnitTests.Logging
             data.Steps[1].Messages[0].Should().Contain("Here's a secret");
         }
 
+        [Test]
+        public void DumpTestLogWithArtifacts()
+        {
+            Logger.LogStep("A");
+            Logger.LogArtifact(ArtifactTypes.Screenshot, "a1.png");
+            Logger.LogArtifact(ArtifactTypes.Screenshot, "a2.png");
+            Logger.LogArtifact(ArtifactTypes.Download, "downA.pdf");
+            Logger.LogStep("B");
+            Logger.LogArtifact(ArtifactTypes.Screenshot, "b.png");
+            Logger.LogArtifact(ArtifactTypes.Download, "downB1.pdf");
+            Logger.LogArtifact(ArtifactTypes.Download, "downB2.pdf");
+            Logger.Close();
+
+            using var file = new StreamReader(Logger.TestLogPath);
+            var data = JsonConvert.DeserializeObject<TestLogData>(file.ReadToEnd());
+
+            data.Name.Should().Be("Unit Test");
+            data.Steps.Count.Should().Be(2);
+
+            data.Steps[0].Name.Should().Be("A");
+            data.Steps[0].Messages.Count.Should().Be(3);
+            data.Steps[0].Messages[0].Should().EndWith("Screenshot: a1.png");
+            data.Steps[0].Messages[1].Should().EndWith("Screenshot: a2.png");
+            data.Steps[0].Messages[2].Should().EndWith("Download: downA.pdf");
+            data.Steps[0].Artifacts.Count.Should().Be(2);
+            data.Steps[0].Artifacts[ArtifactTypes.Screenshot].Count.Should().Be(2);
+            data.Steps[0].Artifacts[ArtifactTypes.Screenshot][0].Should().Be("a1.png");
+            data.Steps[0].Artifacts[ArtifactTypes.Screenshot][1].Should().Be("a2.png");
+            data.Steps[0].Artifacts[ArtifactTypes.Download].Count.Should().Be(1);
+            data.Steps[0].Artifacts[ArtifactTypes.Download][0].Should().Be("downA.pdf");
+
+            data.Steps[1].Name.Should().Be("B");
+            data.Steps[1].Messages.Count.Should().Be(3);
+            data.Steps[1].Messages[0].Should().EndWith("Screenshot: b.png");
+            data.Steps[1].Messages[1].Should().EndWith("Download: downB1.pdf");
+            data.Steps[1].Messages[2].Should().EndWith("Download: downB2.pdf");
+            data.Steps[1].Artifacts.Count.Should().Be(2);
+            data.Steps[1].Artifacts[ArtifactTypes.Screenshot].Count.Should().Be(1);
+            data.Steps[1].Artifacts[ArtifactTypes.Screenshot][0].Should().Be("b.png");
+            data.Steps[1].Artifacts[ArtifactTypes.Download].Count.Should().Be(2);
+            data.Steps[1].Artifacts[ArtifactTypes.Download][0].Should().Be("downB1.pdf");
+            data.Steps[1].Artifacts[ArtifactTypes.Download][1].Should().Be("downB2.pdf");
+        }
+
         #endregion
     }
 }

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/Logging/Exceptions/LoggingException.cs
+++ b/Boa.Constrictor/Logging/Exceptions/LoggingException.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Boa.Constrictor.Logging
+{
+    /// <summary>
+    /// Should be used for any Boa Constrictor logging exceptions.
+    /// </summary>
+    public class LoggingException : Exception
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Empty constructor.
+        /// </summary>
+        public LoggingException() { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        public LoggingException(string message) : base(message) { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        /// <param name="inner">The inner exception.</param>
+        public LoggingException(string message, Exception inner) : base(message, inner) { }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor/Logging/Loggers/TeeLogger.cs
+++ b/Boa.Constrictor/Logging/Loggers/TeeLogger.cs
@@ -106,6 +106,18 @@ namespace Boa.Constrictor.Logging
         }
 
         /// <summary>
+        /// Logs an artifact for each inner logger.
+        /// The artifact must be saved to a file, like a screenshot image or a JSON dump.
+        /// </summary>
+        /// <param name="type">The name for the type of artifact.</param>
+        /// <param name="path">The file path to the artifact.</param>
+        public override void LogArtifact(string type, string path)
+        {
+            foreach (ILogger logger in Loggers.Values)
+                logger.LogArtifact(type, path);
+        }
+
+        /// <summary>
         /// Logs a basic message to each inner logger.
         /// Lowest log severity is not considered.
         /// </summary>

--- a/Boa.Constrictor/Logging/Loggers/TestLogger.cs
+++ b/Boa.Constrictor/Logging/Loggers/TestLogger.cs
@@ -1,0 +1,97 @@
+﻿using Boa.Constrictor.Dumping;
+
+namespace Boa.Constrictor.Logging
+{
+    /// <summary>
+    /// Logs messages to a JSON log file for one test case.
+    /// Breaks test case logging into steps.
+    /// Uses TestCaseData and StepArtifactData for JSON serialization.
+    /// </summary>
+    public class TestLogger : AbstractLogger
+    {
+        #region Properties
+
+        /// <summary>
+        /// The test log directory where to dump the JSON file upon closing the logger.
+        /// </summary>
+        public string TestLogDir { get; private set; }
+
+        /// <summary>
+        /// The test log path where the JSON file is dumped.
+        /// This value will be null until the file is dumped upon closing the logger.
+        /// </summary>
+        public string TestLogPath { get; private set; }
+
+        /// <summary>
+        /// The test case data being logged.
+        /// </summary>
+        private TestLogData Data { get; set; }
+
+        /// <summary>
+        /// The current step data object.
+        /// </summary>
+        private StepArtifactData CurrentStep { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="testName">The test case name.</param>
+        /// <param name="testLogDir">The test log directory where to dump the JSON file upon closing the logger.</param>
+        /// <param name="lowestSeverity">The lowest severity message to log.</param>
+        public TestLogger(string testName, string testLogDir, LogSeverity lowestSeverity = LogSeverity.Trace) :
+            base(lowestSeverity: lowestSeverity)
+        {
+            TestLogDir = testLogDir;
+            TestLogPath = null;
+            Data = new TestLogData(testName);
+        }
+
+        #endregion
+
+        #region Overridden Methods
+
+        /// <summary>
+        /// Closes the logger and writes the test log as a JSON file.
+        /// </summary>
+        public override void Close()
+        {
+            var dumper = new JsonDumper("Test Log Dumper", TestLogDir, "TestLog");
+            TestLogPath = dumper.Dump(Data);
+        }
+
+        /// <summary>
+        /// Logs a raw message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="severity">The log severity.</param>
+        protected override void LogRaw(string message, LogSeverity severity = LogSeverity.Info)
+        {
+            if (CurrentStep == null)
+                throw new LoggingException("TestFileLogger does not have its first step");
+
+            CurrentStep.Messages.Add(MessageFormat.StandardTimestamp(message, severity));
+        }
+
+        #endregion
+
+        #region New Methods
+
+        /// <summary>
+        /// Logs a new step.
+        /// Internally adds new step data.
+        /// All messages and artifacts will be logged under this new step.
+        /// </summary>
+        /// <param name="name">The test step name.</param>
+        public void LogStep(string name)
+        {
+            CurrentStep = new StepArtifactData(name);
+            Data.Steps.Add(CurrentStep);
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor/Logging/Loggers/TestLogger.cs
+++ b/Boa.Constrictor/Logging/Loggers/TestLogger.cs
@@ -52,7 +52,7 @@ namespace Boa.Constrictor.Logging
 
         #endregion
 
-        #region Overridden Methods
+        #region Overridden Log Methods
 
         /// <summary>
         /// Closes the logger and writes the test log as a JSON file.
@@ -61,6 +61,18 @@ namespace Boa.Constrictor.Logging
         {
             var dumper = new JsonDumper("Test Log Dumper", TestLogDir, "TestLog");
             TestLogPath = dumper.Dump(Data);
+        }
+
+        /// <summary>
+        /// Logs an artifact.
+        /// The artifact must be saved to a file, like a screenshot image or a JSON dump.
+        /// </summary>
+        /// <param name="type">The name for the type of artifact.</param>
+        /// <param name="path">The file path to the artifact.</param>
+        public override void LogArtifact(string type, string path)
+        {
+            base.LogArtifact(type, path);
+            CurrentStep.AddArtifact(type, path);
         }
 
         /// <summary>
@@ -78,7 +90,7 @@ namespace Boa.Constrictor.Logging
 
         #endregion
 
-        #region New Methods
+        #region New Log Methods
 
         /// <summary>
         /// Logs a new step.

--- a/Boa.Constrictor/Logging/Messages/MessageFormat.cs
+++ b/Boa.Constrictor/Logging/Messages/MessageFormat.cs
@@ -27,10 +27,8 @@ namespace Boa.Constrictor.Logging
         /// <param name="message">The message text.</param>
         /// <param name="severity">The log severity level.</param>
         /// <returns></returns>
-        public static string StandardTimestamp(string message, LogSeverity severity)
-        {
-            return StandardTimestamp(message, severity.ToString());
-        }
+        public static string StandardTimestamp(string message, LogSeverity severity) =>
+            StandardTimestamp(message, severity.ToString());
 
         #endregion
     }

--- a/Boa.Constrictor/Logging/Models/ArtifactTypes.cs
+++ b/Boa.Constrictor/Logging/Models/ArtifactTypes.cs
@@ -1,0 +1,24 @@
+﻿namespace Boa.Constrictor.Logging
+{
+    /// <summary>
+    /// Provides string constants for logging artifacts.
+    /// Strings are used instead of enumerations so that loggers can technically log any type of artifact.
+    /// </summary>
+    public class ArtifactTypes
+    {
+        /// <summary>
+        /// Artifact type for downloaded files.
+        /// </summary>
+        public const string Download = "Download";
+
+        /// <summary>
+        /// Artifact type for request data dump files.
+        /// </summary>
+        public const string Request = "Request";
+
+        /// <summary>
+        /// Artifact type for screenshot images.
+        /// </summary>
+        public const string Screenshot = "Screenshot";
+    }
+}

--- a/Boa.Constrictor/Logging/Models/ArtifactTypes.cs
+++ b/Boa.Constrictor/Logging/Models/ArtifactTypes.cs
@@ -9,16 +9,16 @@
         /// <summary>
         /// Artifact type for downloaded files.
         /// </summary>
-        public const string Download = "Download";
+        public const string Downloads = "Downloads";
 
         /// <summary>
         /// Artifact type for request data dump files.
         /// </summary>
-        public const string Request = "Request";
+        public const string Requests = "Requests";
 
         /// <summary>
         /// Artifact type for screenshot images.
         /// </summary>
-        public const string Screenshot = "Screenshot";
+        public const string Screenshots = "Screenshots";
     }
 }

--- a/Boa.Constrictor/Logging/Models/StepArtifactData.cs
+++ b/Boa.Constrictor/Logging/Models/StepArtifactData.cs
@@ -25,22 +25,12 @@ namespace Boa.Constrictor.Logging
         public IList<string> Messages { get; private set; }
 
         /// <summary>
-        /// Screenshot paths for the test step.
+        /// Artifacts for the steps.
+        /// Each artifact has a type (which is the key name) and a path (which should be a list entry).
+        /// Strings are used so that callers can use any artifact type for a key.
         /// </summary>
         [JsonProperty]
-        public IList<string> Screenshots { get; private set; }
-
-        /// <summary>
-        /// Request dump paths for the test step.
-        /// </summary>
-        [JsonProperty]
-        public IList<string> Requests { get; private set; }
-
-        /// <summary>
-        /// Downloaded file paths for the test step.
-        /// </summary>
-        [JsonProperty]
-        public IList<string> Downloads { get; private set; }
+        public IDictionary<string, IList<string>> Artifacts { get; private set; }
 
         #endregion
 
@@ -62,9 +52,25 @@ namespace Boa.Constrictor.Logging
         {
             Name = name;
             Messages = new List<string>();
-            Screenshots = new List<string>();
-            Requests = new List<string>();
-            Downloads = new List<string>();
+            Artifacts = new Dictionary<string, IList<string>>();
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Adds an artifact to this step data.
+        /// Artifacts are files, like screenshot images or JSON data dumps.
+        /// </summary>
+        /// <param name="type">The type of artifact to add.</param>
+        /// <param name="path">The file path to the artifact.</param>
+        public void AddArtifact(string type, string path)
+        {
+            if (!Artifacts.ContainsKey(type))
+                Artifacts[type] = new List<string>();
+
+            Artifacts[type].Add(path);
         }
 
         #endregion

--- a/Boa.Constrictor/Logging/Models/StepArtifactData.cs
+++ b/Boa.Constrictor/Logging/Models/StepArtifactData.cs
@@ -1,0 +1,72 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Boa.Constrictor.Logging
+{
+    /// <summary>
+    /// Models data for one test step.
+    /// Can be used directly for JSON serialization.
+    /// Used by TestLogger.
+    /// </summary>
+    public class StepArtifactData
+    {
+        #region Properties
+
+        /// <summary>
+        /// The name of the test step.
+        /// </summary>
+        [JsonProperty]
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Log messages for the test step.
+        /// </summary>
+        [JsonProperty]
+        public IList<string> Messages { get; private set; }
+
+        /// <summary>
+        /// Screenshot paths for the test step.
+        /// </summary>
+        [JsonProperty]
+        public IList<string> Screenshots { get; private set; }
+
+        /// <summary>
+        /// Request dump paths for the test step.
+        /// </summary>
+        [JsonProperty]
+        public IList<string> Requests { get; private set; }
+
+        /// <summary>
+        /// Downloaded file paths for the test step.
+        /// </summary>
+        [JsonProperty]
+        public IList<string> Downloads { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Default constructor.
+        /// Initializes the step name to be blank.
+        /// Initializes all artifact lists to be empty.
+        /// </summary>
+        public StepArtifactData() : this("") { }
+
+        /// <summary>
+        /// Constructor.
+        /// Initializes all artifact lists to be empty.
+        /// </summary>
+        /// <param name="name">The name of the test step.</param>
+        public StepArtifactData(string name)
+        {
+            Name = name;
+            Messages = new List<string>();
+            Screenshots = new List<string>();
+            Requests = new List<string>();
+            Downloads = new List<string>();
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor/Logging/Models/TestLogData.cs
+++ b/Boa.Constrictor/Logging/Models/TestLogData.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Boa.Constrictor.Logging
+{
+    /// <summary>
+    /// Models data for one test case.
+    /// Can be used directly for JSON serialization.
+    /// Used by TestLogger.
+    /// </summary>
+    public class TestLogData
+    {
+        #region Properties
+
+        /// <summary>
+        /// The test name.
+        /// </summary>
+        [JsonProperty]
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// The test steps.
+        /// </summary>
+        [JsonProperty]
+        public IList<StepArtifactData> Steps { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Default constructor.
+        /// Initializes the test name to be blank.
+        /// Initializes the list of steps to be empty.
+        /// </summary>
+        public TestLogData() : this("") { }
+
+        /// <summary>
+        /// Constructor.
+        /// Initializes the list of steps to be empty.
+        /// </summary>
+        /// <param name="name">The test name.</param>
+        public TestLogData(string name)
+        {
+            Name = name;
+            Steps = new List<StepArtifactData>();
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor/Logging/Parents/AbstractLogger.cs
+++ b/Boa.Constrictor/Logging/Parents/AbstractLogger.cs
@@ -58,6 +58,14 @@
                 LogRaw(message, severity: severity);
         }
 
+        /// <summary>
+        /// Logs an artifact.
+        /// The artifact must be saved to a file, like a screenshot image or a JSON dump.
+        /// </summary>
+        /// <param name="type">The name for the type of artifact.</param>
+        /// <param name="path">The file path to the artifact.</param>
+        public virtual void LogArtifact(string type, string path) => Info($"{type}: {path}");
+
         #endregion
 
         #region Log-by-Level Methods

--- a/Boa.Constrictor/Logging/Parents/ILogger.cs
+++ b/Boa.Constrictor/Logging/Parents/ILogger.cs
@@ -29,6 +29,14 @@
         /// <param name="severity">The severity level (defaults to Info).</param>
         void Log(string message, LogSeverity severity = LogSeverity.Info);
 
+        /// <summary>
+        /// Logs an artifact.
+        /// The artifact must be saved to a file, like a screenshot image or a JSON dump.
+        /// </summary>
+        /// <param name="type">The name for the type of artifact.</param>
+        /// <param name="path">The file path to the artifact.</param>
+        void LogArtifact(string type, string path);
+
         #endregion
 
         #region Log-by-Level Methods

--- a/Boa.Constrictor/RestSharp/Interactions/AbstractRestQuestion.cs
+++ b/Boa.Constrictor/RestSharp/Interactions/AbstractRestQuestion.cs
@@ -1,4 +1,5 @@
-﻿using Boa.Constrictor.Screenplay;
+﻿using Boa.Constrictor.Logging;
+using Boa.Constrictor.Screenplay;
 using RestSharp;
 using System;
 
@@ -84,7 +85,7 @@ namespace Boa.Constrictor.RestSharp
                 {
                     // Dump the file
                     string path = ability.DownloadDumper.Dump(fileBytes, fileExtension);
-                    actor.Logger.Info($"Dumped downloaded file to: {path}");
+                    actor.Logger.LogArtifact(ArtifactTypes.Request, path);
 
                     // Warn about blank file extensions
                     if (fileExtension == "")
@@ -130,7 +131,7 @@ namespace Boa.Constrictor.RestSharp
                 {
                     // Try to dump the request and the response
                     string path = ability.RequestDumper.Dump(ability.Client, Request, response, start, end);
-                    actor.Logger.Info($"Dumped request to: {path}");
+                    actor.Logger.LogArtifact(ArtifactTypes.Download, path);
                 }
                 else
                 {

--- a/Boa.Constrictor/RestSharp/Interactions/AbstractRestQuestion.cs
+++ b/Boa.Constrictor/RestSharp/Interactions/AbstractRestQuestion.cs
@@ -85,7 +85,7 @@ namespace Boa.Constrictor.RestSharp
                 {
                     // Dump the file
                     string path = ability.DownloadDumper.Dump(fileBytes, fileExtension);
-                    actor.Logger.LogArtifact(ArtifactTypes.Request, path);
+                    actor.Logger.LogArtifact(ArtifactTypes.Downloads, path);
 
                     // Warn about blank file extensions
                     if (fileExtension == "")
@@ -131,7 +131,7 @@ namespace Boa.Constrictor.RestSharp
                 {
                     // Try to dump the request and the response
                     string path = ability.RequestDumper.Dump(ability.Client, Request, response, start, end);
-                    actor.Logger.LogArtifact(ArtifactTypes.Download, path);
+                    actor.Logger.LogArtifact(ArtifactTypes.Requests, path);
                 }
                 else
                 {

--- a/Boa.Constrictor/WebDriver/Questions/CurrentScreenshot.cs
+++ b/Boa.Constrictor/WebDriver/Questions/CurrentScreenshot.cs
@@ -1,4 +1,5 @@
-﻿using Boa.Constrictor.Screenplay;
+﻿using Boa.Constrictor.Logging;
+using Boa.Constrictor.Screenplay;
 using Boa.Constrictor.Utilities;
 using OpenQA.Selenium;
 using System.IO;
@@ -110,9 +111,9 @@ namespace Boa.Constrictor.WebDriver
                 fileName = Path.GetFileNameWithoutExtension(fileName);
             }
             
-            // Create the output directory if it doesn't exist.
             if (!Directory.Exists(OutputDir))
             {
+                // Create the output directory if it doesn't exist.
                 actor.Logger.Debug($"Creating screenshot directory '{OutputDir}'");
                 Directory.CreateDirectory(OutputDir);
             }
@@ -120,7 +121,7 @@ namespace Boa.Constrictor.WebDriver
             // Capture and save the screenshot.
             string path = Path.Combine(OutputDir, $"{fileName}.{Format.ToString().ToLower()}");
             (driver as ITakesScreenshot).GetScreenshot().SaveAsFile(path, Format);
-            actor.Logger.Info($"Screen shot taken at: {path}");
+            actor.Logger.LogArtifact(ArtifactTypes.Screenshot, path);
 
             // Return the path to the screenshot image file.
             return path;

--- a/Boa.Constrictor/WebDriver/Questions/CurrentScreenshot.cs
+++ b/Boa.Constrictor/WebDriver/Questions/CurrentScreenshot.cs
@@ -121,7 +121,7 @@ namespace Boa.Constrictor.WebDriver
             // Capture and save the screenshot.
             string path = Path.Combine(OutputDir, $"{fileName}.{Format.ToString().ToLower()}");
             (driver as ITakesScreenshot).GetScreenshot().SaveAsFile(path, Format);
-            actor.Logger.LogArtifact(ArtifactTypes.Screenshot, path);
+            actor.Logger.LogArtifact(ArtifactTypes.Screenshots, path);
 
             // Return the path to the screenshot image file.
             return path;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.8.0] - 2021-01-06
+
+### Added
+
+- Added `TestLogger` for dumping JSON files with test steps, messages, and test artifact files
+
+
 ## [0.7.0] - 2020-12-22
 
 ### Added


### PR DESCRIPTION
`TestLogger` dumps a JSON file for a test case containing messages and test artifacts by step. `ILogger` also now has a `LogArtifact` method for specifically logging artifacts. I added unit tests for these new things, and I also did local testing with PrecisionLender's test suite to verify correctness.

This change also increases the version to 0.8.0.