### PR TITLE
Updated TestLogData and TestLogger

### DIFF
--- a/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
+++ b/Boa.Constrictor.UnitTests/Logging/Loggers/TestLoggerTest.cs
@@ -12,6 +12,7 @@ namespace Boa.Constrictor.UnitTests.Logging
     {
         #region Variables
 
+        private string TestLogDir;
         private TestLogger Logger;
 
         #endregion
@@ -21,8 +22,8 @@ namespace Boa.Constrictor.UnitTests.Logging
         [SetUp]
         public void SetUp()
         {
-            string dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            Logger = new TestLogger("Unit Test", dir);
+            TestLogDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            Logger = new TestLogger("Unit Test", TestLogDir);
         }
 
         [TearDown]
@@ -37,6 +38,103 @@ namespace Boa.Constrictor.UnitTests.Logging
         #region Tests
 
         [Test]
+        public void Init()
+        {
+            Logger.Data.Name.Should().Be("Unit Test");
+            Logger.Data.Result.Should().BeNull();
+            Logger.Data.Steps.Should().BeEmpty();
+            Logger.TestLogDir.Should().Be(TestLogDir);
+            Logger.TestLogPath.Should().BeNull();
+            Logger.CurrentStep.Should().BeNull();
+        }
+
+        public void LogResult()
+        {
+            Logger.LogResult("Pass");
+            Logger.Data.Result.Should().Be("Pass");
+        }
+
+        [Test]
+        public void LogStep()
+        {
+            Logger.LogStep("One");
+            Logger.Data.Steps.Count.Should().Be(1);
+            Logger.Data.Steps[0].Should().Be(Logger.CurrentStep);
+            Logger.CurrentStep.Name.Should().Be("One");
+            Logger.CurrentStep.Messages.Should().BeEmpty();
+            Logger.CurrentStep.Artifacts.Should().BeEmpty();
+        }
+
+        [Test]
+        public void LogWithoutStep()
+        {
+            Logger.Invoking(x => x.Info("message"))
+                .Should().Throw<LoggingException>()
+                .WithMessage("TestLogger does not have its first step");
+        }
+
+        [Test]
+        public void LogArtifact()
+        {
+            const string type = "Screenshot";
+            const string path = "path/to/screen.png";
+
+            Logger.LogStep("first");
+            Logger.LogArtifact(type, path);
+            Logger.Data.Steps[0].Messages.Count.Should().Be(1);
+            Logger.Data.Steps[0].Messages[0].Should().EndWith($"{type}: {path}");
+            Logger.Data.Steps[0].Artifacts.Count.Should().Be(1);
+            Logger.Data.Steps[0].Artifacts[type].Count.Should().Be(1);
+            Logger.Data.Steps[0].Artifacts[type][0].Should().Be(path);
+        }
+
+        [TestCase("Trace")]
+        [TestCase("Debug")]
+        [TestCase("Info")]
+        [TestCase("Warning")]
+        [TestCase("Error")]
+        [TestCase("Fatal")]
+        public void LogByLevel(string level)
+        {
+            const string message = "Message text!";
+
+            Logger.LogStep("first");
+            Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
+            Logger.Data.Steps[0].Messages.Count.Should().Be(1);
+            Logger.Data.Steps[0].Messages[0].Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[{level.ToUpper()}] {message}");
+        }
+
+        [TestCase("Info")]
+        [TestCase("Warning")]
+        [TestCase("Error")]
+        [TestCase("Fatal")]
+        public void LowestSeverityLogged(string level)
+        {
+            const string message = "Message text!";
+
+            Logger.LowestSeverity = LogSeverity.Info;
+            Logger.LogStep("first");
+            Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
+            Logger.Data.Steps[0].Messages.Count.Should().Be(1);
+            Logger.Data.Steps[0].Messages[0].Should().MatchRegex(MessageFormatTest.TimePattern).And.EndWith($"[{level.ToUpper()}] {message}");
+        }
+
+        [TestCase("Trace")]
+        [TestCase("Debug")]
+        [TestCase("Info")]
+        [TestCase("Warning")]
+        [TestCase("Error")]
+        public void LowestSeverityBlocked(string level)
+        {
+            const string message = "Message text!";
+
+            Logger.LowestSeverity = LogSeverity.Fatal;
+            Logger.LogStep("first");
+            Logger.GetType().GetMethod(level).Invoke(Logger, new object[] { message });
+            Logger.Data.Steps[0].Messages.Should().BeEmpty();
+        }
+
+        [Test]
         public void DumpEmptyTestLog()
         {
             Logger.Close();
@@ -49,55 +147,38 @@ namespace Boa.Constrictor.UnitTests.Logging
         }
 
         [Test]
-        public void DumpTestLogWithMessages()
-        {
-            Logger.LogStep("A");
-            Logger.Info("Hello");
-            Logger.Warning("Oh no!");
-            Logger.Error("ERROR");
-            Logger.LogStep("B");
-            Logger.Debug("Here's a secret");
-            Logger.Close();
-
-            using var file = new StreamReader(Logger.TestLogPath);
-            var data = JsonConvert.DeserializeObject<TestLogData>(file.ReadToEnd());
-
-            data.Name.Should().Be("Unit Test");
-            data.Steps.Count.Should().Be(2);
-            data.Steps[0].Name.Should().Be("A");
-            data.Steps[0].Messages.Count.Should().Be(3);
-            data.Steps[0].Messages[0].Should().Contain("Hello");
-            data.Steps[0].Messages[1].Should().Contain("Oh no!");
-            data.Steps[0].Messages[2].Should().Contain("ERROR");
-            data.Steps[1].Name.Should().Be("B");
-            data.Steps[1].Messages.Count.Should().Be(1);
-            data.Steps[1].Messages[0].Should().Contain("Here's a secret");
-        }
-
-        [Test]
-        public void DumpTestLogWithArtifacts()
+        public void DumpFullLog()
         {
             Logger.LogStep("A");
             Logger.LogArtifact(ArtifactTypes.Screenshots, "a1.png");
             Logger.LogArtifact(ArtifactTypes.Screenshots, "a2.png");
             Logger.LogArtifact(ArtifactTypes.Downloads, "downA.pdf");
+            Logger.Info("Hello");
+            Logger.Warning("Oh no!");
+            Logger.Error("ERROR");
             Logger.LogStep("B");
             Logger.LogArtifact(ArtifactTypes.Screenshots, "b.png");
             Logger.LogArtifact(ArtifactTypes.Downloads, "downB1.pdf");
             Logger.LogArtifact(ArtifactTypes.Downloads, "downB2.pdf");
+            Logger.Debug("Here's a secret");
+            Logger.LogResult("Fail");
             Logger.Close();
 
             using var file = new StreamReader(Logger.TestLogPath);
             var data = JsonConvert.DeserializeObject<TestLogData>(file.ReadToEnd());
 
             data.Name.Should().Be("Unit Test");
+            data.Result.Should().Be("Fail");
             data.Steps.Count.Should().Be(2);
 
             data.Steps[0].Name.Should().Be("A");
-            data.Steps[0].Messages.Count.Should().Be(3);
+            data.Steps[0].Messages.Count.Should().Be(6);
             data.Steps[0].Messages[0].Should().EndWith("Screenshots: a1.png");
             data.Steps[0].Messages[1].Should().EndWith("Screenshots: a2.png");
             data.Steps[0].Messages[2].Should().EndWith("Downloads: downA.pdf");
+            data.Steps[0].Messages[3].Should().Contain("Hello");
+            data.Steps[0].Messages[4].Should().Contain("Oh no!");
+            data.Steps[0].Messages[5].Should().Contain("ERROR");
             data.Steps[0].Artifacts.Count.Should().Be(2);
             data.Steps[0].Artifacts[ArtifactTypes.Screenshots].Count.Should().Be(2);
             data.Steps[0].Artifacts[ArtifactTypes.Screenshots][0].Should().Be("a1.png");
@@ -106,10 +187,11 @@ namespace Boa.Constrictor.UnitTests.Logging
             data.Steps[0].Artifacts[ArtifactTypes.Downloads][0].Should().Be("downA.pdf");
 
             data.Steps[1].Name.Should().Be("B");
-            data.Steps[1].Messages.Count.Should().Be(3);
+            data.Steps[1].Messages.Count.Should().Be(4);
             data.Steps[1].Messages[0].Should().EndWith("Screenshots: b.png");
             data.Steps[1].Messages[1].Should().EndWith("Downloads: downB1.pdf");
             data.Steps[1].Messages[2].Should().EndWith("Downloads: downB2.pdf");
+            data.Steps[1].Messages[3].Should().Contain("Here's a secret");
             data.Steps[1].Artifacts.Count.Should().Be(2);
             data.Steps[1].Artifacts[ArtifactTypes.Screenshots].Count.Should().Be(1);
             data.Steps[1].Artifacts[ArtifactTypes.Screenshots][0].Should().Be("b.png");

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/Logging/Loggers/TestLogger.cs
+++ b/Boa.Constrictor/Logging/Loggers/TestLogger.cs
@@ -25,12 +25,12 @@ namespace Boa.Constrictor.Logging
         /// <summary>
         /// The test case data being logged.
         /// </summary>
-        private TestLogData Data { get; set; }
+        public TestLogData Data { get; private set; }
 
         /// <summary>
         /// The current step data object.
         /// </summary>
-        private StepArtifactData CurrentStep { get; set; }
+        public StepArtifactData CurrentStep { get; private set; }
 
         #endregion
 
@@ -48,6 +48,7 @@ namespace Boa.Constrictor.Logging
             TestLogDir = testLogDir;
             TestLogPath = null;
             Data = new TestLogData(testName);
+            CurrentStep = null;
         }
 
         #endregion
@@ -83,7 +84,7 @@ namespace Boa.Constrictor.Logging
         protected override void LogRaw(string message, LogSeverity severity = LogSeverity.Info)
         {
             if (CurrentStep == null)
-                throw new LoggingException("TestFileLogger does not have its first step");
+                throw new LoggingException("TestLogger does not have its first step");
 
             CurrentStep.Messages.Add(MessageFormat.StandardTimestamp(message, severity));
         }
@@ -91,6 +92,15 @@ namespace Boa.Constrictor.Logging
         #endregion
 
         #region New Log Methods
+
+        /// <summary>
+        /// Logs the test result.
+        /// </summary>
+        /// <param name="result">The test result.</param>
+        public void LogResult(string result)
+        {
+            Data.Result = result;
+        }
 
         /// <summary>
         /// Logs a new step.

--- a/Boa.Constrictor/Logging/Models/TestLogData.cs
+++ b/Boa.Constrictor/Logging/Models/TestLogData.cs
@@ -17,6 +17,13 @@ namespace Boa.Constrictor.Logging
         /// </summary>
         [JsonProperty]
         public string Name { get; private set; }
+        
+        /// <summary>
+        /// The test result.
+        /// This is a string value so that it may be free form.
+        /// </summary>
+        [JsonProperty]
+        public string Result { get; set; }
 
         /// <summary>
         /// The test steps.
@@ -43,6 +50,7 @@ namespace Boa.Constrictor.Logging
         public TestLogData(string name)
         {
             Name = name;
+            Result = null;
             Steps = new List<StepArtifactData>();
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.8.1] - 2021-01-07
+
+### Changed
+
+- `TestLogData` now has a `Result` property for storing the test result
+- `TestLogData`'s properties are all now public to *get* but remain private to *set*
+- `TestLogger` now has a `LogResult` method for logging the test result
+
+
 ## [0.8.0] - 2021-01-06
 
 ### Added


### PR DESCRIPTION
Changes:
- `TestLogData` now has a `Result` property for storing the test result
- `TestLogData`'s properties are all now public to *get* but remain private to *set*
- `TestLogger` now has a `LogResult` method for logging the test result

This change also increases the version to **Boa Constrictor 0.8.1**.
