### PR TITLE
Added Test Log HTML Report

### DIFF
--- a/Boa.Constrictor.UnitTests/Dumping/Dumpers/TestLogReportDumperTest.cs
+++ b/Boa.Constrictor.UnitTests/Dumping/Dumpers/TestLogReportDumperTest.cs
@@ -1,0 +1,133 @@
+﻿using Boa.Constrictor.Dumping;
+using Boa.Constrictor.Logging;
+using FluentAssertions;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace Boa.Constrictor.UnitTests.Dumping
+{
+    [TestFixture]
+    public class TestLogReportDumperTest
+    {
+        #region Variables
+
+        private string AssemblyDir;
+        private TestLogReportDumper Dumper;
+        private string FilePath;
+
+        #endregion
+
+        #region Setup and Teardown
+
+        [SetUp]
+        public void SetUp()
+        {
+            AssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            Dumper = new TestLogReportDumper("Test Log Report Dumper", AssemblyDir, "TestLogReport", "Boa Test Logs");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(FilePath))
+                File.Delete(FilePath);
+        }
+
+        #endregion
+
+        #region Tests
+
+        [Test]
+        public void DumpReport()
+        {
+            // WARNING!
+            // This unit test does NOT validate the contents of the generated report.
+            // It simply verifies that the report is written to a non-empty file.
+            // Reports require visual testing because their contents are likely to change.
+            // It would be better to manually inspect report contents than to unit test them.
+            // Therefore, when making report changes, it is recommended to set a break point, debug, and manually view the file.
+
+            string sspath = Path.Combine(AssemblyDir, "a.png");
+            string rpath = Path.Combine(AssemblyDir, "r.json");
+
+            // Create test 1
+            var t1step1 = new StepArtifactData("Step 1");
+            t1step1.Messages.Add("Hello");
+            t1step1.Messages.Add("Moto");
+            t1step1.AddArtifact("Screenshots", sspath);
+            t1step1.AddArtifact("Requests", rpath);
+            var t1step2 = new StepArtifactData("Step 2");
+            t1step2.Messages.Add("Moar");
+            t1step2.Messages.Add("MoarMoar");
+            t1step2.AddArtifact("Screenshots", sspath);
+            var test1 = new TestLogData("Test 1");
+            test1.Result = "Passed";
+            test1.Steps.Add(t1step1);
+            test1.Steps.Add(t1step2);
+
+            // Create test 2
+            var t2step1 = new StepArtifactData("Step 1");
+            t2step1.Messages.Add("Second Hello");
+            t2step1.Messages.Add("Second Moto");
+            t2step1.AddArtifact("Screenshots", sspath);
+            t2step1.AddArtifact("Requests", rpath);
+            var t2step2 = new StepArtifactData("Step 2");
+            t2step2.Messages.Add("Enough!");
+            t2step2.Messages.Add("Stahp!");
+            t2step2.AddArtifact("Screenshots", sspath);
+            var test2 = new TestLogData("Test 2");
+            test2.Result = "Failed";
+            test2.Steps.Add(t2step1);
+            test2.Steps.Add(t2step2);
+
+
+            // Create test 3
+            var t3step1 = new StepArtifactData("Step 1");
+            t3step1.Messages.Add("A");
+            t3step1.Messages.Add("B");
+            t3step1.Messages.Add("C");
+            t3step1.Messages.Add("D");
+            t3step1.AddArtifact("Screenshots", sspath);
+            t3step1.AddArtifact("Requests", rpath);
+            var test3 = new TestLogData("Test 3");
+            test3.Result = "Skipped";
+            test3.Steps.Add(t3step1);
+
+            // Create list of logs
+            var logs = new List<TestLogData>
+            {
+                test1,
+                test2,
+                test3
+            };
+
+            // Dump the report
+            FilePath = Dumper.Dump(logs, relativePath: AssemblyDir);
+
+            // Read and verify the report
+            using var file = new StreamReader(FilePath);
+            string report = file.ReadToEnd();
+            report.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Test]
+        public void DumpEmptyList()
+        {
+            FilePath = Dumper.Dump(new List<TestLogData>());
+
+            using var file = new StreamReader(FilePath);
+            string report = file.ReadToEnd();
+            report.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Test]
+        public void DumpNull()
+        {
+            Dumper.Invoking(d => d.Dump(null)).Should().Throw<DumpingException>();
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor.UnitTests/Dumping/Dumpers/TestLogReportDumperTest.cs
+++ b/Boa.Constrictor.UnitTests/Dumping/Dumpers/TestLogReportDumperTest.cs
@@ -82,7 +82,6 @@ namespace Boa.Constrictor.UnitTests.Dumping
             test2.Steps.Add(t2step1);
             test2.Steps.Add(t2step2);
 
-
             // Create test 3
             var t3step1 = new StepArtifactData("Step 1");
             t3step1.Messages.Add("A");

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/Dumping/Dumpers/ByteDumper.cs
+++ b/Boa.Constrictor/Dumping/Dumpers/ByteDumper.cs
@@ -7,15 +7,6 @@ namespace Boa.Constrictor.Dumping
     /// </summary>
     public class ByteDumper : AbstractDumper
     {
-        #region Properties
-
-        /// <summary>
-        /// The token for the file name.
-        /// </summary>
-        public string FileToken { get; private set; }
-
-        #endregion
-
         #region Constructors
 
         /// <summary>
@@ -25,7 +16,8 @@ namespace Boa.Constrictor.Dumping
         /// <param name="dumpDir">The output directory for dumping requests and responses.</param>
         /// <param name="fileToken">The token for the file name.</param>
         public ByteDumper(string name, string dumpDir, string fileToken) :
-            base(name, dumpDir) => FileToken = fileToken;
+            base(name, dumpDir, fileToken)
+        { }
 
         #endregion
 
@@ -45,7 +37,7 @@ namespace Boa.Constrictor.Dumping
                 throw new DumpingException($"Dumper \"{Name}\" cannot dump null data");
 
             // Get the path for the file
-            string path = GetDumpFilePath(FileToken, extension);
+            string path = GetDumpFilePath(extension);
 
             // Write the file
             File.WriteAllBytes(path, data);

--- a/Boa.Constrictor/Dumping/Dumpers/JsonDumper.cs
+++ b/Boa.Constrictor/Dumping/Dumpers/JsonDumper.cs
@@ -17,15 +17,6 @@ namespace Boa.Constrictor.Dumping
 
         #endregion
 
-        #region Properties
-
-        /// <summary>
-        /// The token for the file name.
-        /// </summary>
-        public string FileToken { get; private set; }
-
-        #endregion
-
         #region Constructors
 
         /// <summary>
@@ -35,7 +26,8 @@ namespace Boa.Constrictor.Dumping
         /// <param name="dumpDir">The output directory for dumping requests and responses.</param>
         /// <param name="fileToken">The token for the file name.</param>
         public JsonDumper(string name, string dumpDir, string fileToken) :
-            base(name, dumpDir) => FileToken = fileToken;
+            base(name, dumpDir, fileToken)
+        { }
 
         #endregion
 
@@ -50,7 +42,7 @@ namespace Boa.Constrictor.Dumping
         public string Dump(object jsonData)
         {
             // Get the path for the file
-            string path = GetDumpFilePath(FileToken, JsonExtension);
+            string path = GetDumpFilePath(JsonExtension);
 
             // Write the JSON file
             using (var file = new StreamWriter(path))

--- a/Boa.Constrictor/Dumping/Dumpers/TestLogReportDumper.cs
+++ b/Boa.Constrictor/Dumping/Dumpers/TestLogReportDumper.cs
@@ -64,11 +64,11 @@ namespace Boa.Constrictor.Dumping
             string background = "";
 
             if (lowerResult.Contains("pass") || lowerResult.Contains("success") || lowerResult.Contains("ok"))
-                background = " background-color: #B8F5B5;";
+                background = " background-color: #B8F5B5;";   // light green
             else if (lowerResult.Contains("fail") || lowerResult.Contains("error") || lowerResult.Contains("fatal"))
-                background = " background-color: #FFCCCB;";
+                background = " background-color: #FFCCCB;";   // light red
             else if (lowerResult.Contains("skip") || lowerResult.Contains("ignore"))
-                background = " background-color: #FFFFCC;";
+                background = " background-color: #FFFFCC;";   // light yellow
 
             return background;
         }

--- a/Boa.Constrictor/Dumping/Dumpers/TestLogReportDumper.cs
+++ b/Boa.Constrictor/Dumping/Dumpers/TestLogReportDumper.cs
@@ -1,0 +1,288 @@
+﻿using Boa.Constrictor.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Boa.Constrictor.Dumping
+{
+    /// <summary>
+    /// Dumps an HTML report that combines all test logs.
+    /// </summary>
+    public class TestLogReportDumper : AbstractDumper
+    {
+        #region Constants
+
+        /// <summary>
+        /// The default title for the report.
+        /// </summary>
+        public const string DefaultTitle = "Test Log Report";
+
+        /// <summary>
+        /// The HTML file extension.
+        /// </summary>
+        public const string HtmlExtension = ".html";
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The report title.
+        /// </summary>
+        public string Title { get; private set; }
+        
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">A descriptive name for the dumper.</param>
+        /// <param name="dumpDir">The output directory for dumping requests and responses.</param>
+        /// <param name="fileToken">The token for the file name.</param>
+        /// <param name="title">The report title.</param>
+        public TestLogReportDumper(string name, string dumpDir, string fileToken, string title = DefaultTitle) :
+            base(name, dumpDir, fileToken) => Title = title;
+
+        #endregion
+
+        #region Private Methods
+        
+        /// <summary>
+        /// Gets CSS text for a result's background color.
+        /// String format: "background-color: #xxxxxx;".
+        /// Returns an empty string if no color is designated for the result.
+        /// </summary>
+        /// <param name="result">The result string.</param>
+        /// <returns></returns>
+        private string GetBackgroundColor(string result)
+        {
+            string lowerResult = result.ToLower();
+            string background = "";
+
+            if (lowerResult.Contains("pass") || lowerResult.Contains("success") || lowerResult.Contains("ok"))
+                background = " background-color: #B8F5B5;";
+            else if (lowerResult.Contains("fail") || lowerResult.Contains("error") || lowerResult.Contains("fatal"))
+                background = " background-color: #FFCCCB;";
+            else if (lowerResult.Contains("skip") || lowerResult.Contains("ignore"))
+                background = " background-color: #FFFFCC;";
+
+            return background;
+        }
+
+        /// <summary>
+        /// Converts a path to an embeddable URI for linking from the HTML report.
+        /// If the absolute path isn't truly absolute, simply return it as a relative URI.
+        /// If no relative path is given, then return the absolute path as a URI.
+        /// If a relative path is given, then return a relative URI for the absolute path.
+        /// </summary>
+        /// <param name="absolute">The absolute file path.</param>
+        /// <param name="relative">The relative directory. May be null or blank.</param>
+        /// <returns></returns>
+        public string ConvertPath(string absolute, string relative = null)
+        {
+            string newPath;
+
+            if (!Path.IsPathRooted(absolute))
+            {
+                newPath = "file:" + absolute;
+            }
+            else if (string.IsNullOrWhiteSpace(relative))
+            {
+                newPath = new Uri(absolute).ToString();
+            }
+            else
+            {
+                if (relative.Last() != '\\')
+                    relative += '\\';
+
+                Uri absoluteUri = new Uri(absolute);
+                Uri relativeUri = new Uri(relative);
+                Uri newUri = relativeUri.MakeRelativeUri(absoluteUri);
+
+                newPath = "file:" + newUri.ToString();
+            }
+
+            return newPath;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Writes the HTML report using the given TestLogData objects.
+        /// Returns the report file's file's path.
+        /// </summary>
+        /// <param name="logs">A list of log data objects.</param>
+        /// <param name="relativePath">If provided, overwrites artifact absolute paths with this relative path.</param>
+        /// <param name="maxScreenshotWidth">Maximum screenshot width in pixels. Defaults to 1500.</param>
+        /// <returns></returns>
+        public string Dump(IList<TestLogData> logs, string relativePath = null, int maxScreenshotWidth=1500)
+        {
+            // Make sure data is not null
+            if (logs == null)
+                throw new DumpingException($"Dumper \"{Name}\" cannot dump null data");
+
+            // Create a string builder
+            StringBuilder html = new StringBuilder();
+
+            // Append HTML doc opener
+            html.AppendLine("<!DOCTYPE html>");
+            html.AppendLine("<html>");
+            html.AppendLine("<head>");
+            html.AppendLine("<title>Test Log Report</title>");
+            html.AppendLine("</head>");
+            html.AppendLine("<body style='font-family: Helvetica, sans-serif;'>");
+            html.AppendLine("<div style='padding: 20px'>");
+            html.AppendLine($"<h1>{Title}</h1>");
+
+            // Append summary div
+            html.AppendLine($"<hr />");
+            html.AppendLine("<div style='padding-left: 25px; padding-bottom: 25px;'>");
+
+            // Append test summary header
+            html.AppendLine($"<h2 style='padding-top: 10px'>Test Summary</h2>");
+            html.AppendLine("<table style='border: 1px solid lightgray; border-collapse: collapse;'>");
+            html.AppendLine("<tr>");
+            html.AppendLine("<th style='border: 1px solid lightgray; padding: 8px; background-color: #EEEEEE;'>Number</th>");
+            html.AppendLine("<th style='border: 1px solid lightgray; padding: 8px; background-color: #EEEEEE;'>Result</th>");
+            html.AppendLine("<th style='border: 1px solid lightgray; padding: 8px; background-color: #EEEEEE;'>Name</th>");
+            html.AppendLine("</tr>");
+
+            // Append test summary
+            int count = 0;
+            foreach (var log in logs)
+            {
+                count++;
+                string background = GetBackgroundColor(log.Result);
+
+                html.AppendLine("<tr>");
+                html.AppendLine($"<td style='border: 1px solid lightgray; padding: 8px'><a href='#test{count}'>{count}</a></td>");
+                html.AppendLine($"<td style='border: 1px solid lightgray; padding: 8px;{background}'>{log.Result}</td>");
+                html.AppendLine($"<td style='border: 1px solid lightgray; padding: 8px'>{log.Name}</td>");
+                html.AppendLine("</tr>");
+            }
+            html.AppendLine("</table>");
+
+            // Append result summary header
+            html.AppendLine($"<h2 style='padding-top: 10px'>Result Summary</h2>");
+            html.AppendLine("<table style='border: 1px solid lightgray; border-collapse: collapse;'>");
+            html.AppendLine("<tr>");
+            html.AppendLine("<th style='border: 1px solid lightgray; padding: 8px; background-color: #EEEEEE;'>Result</th>");
+            html.AppendLine("<th style='border: 1px solid lightgray; padding: 8px; background-color: #EEEEEE;'>Count</th>");
+            html.AppendLine("</tr>");
+
+            // Append result summary 
+            foreach (string result in logs.Select(log => log.Result).Distinct())
+            {
+                int resultCount = logs.Where(log => log.Result == result).Count();
+                string background = GetBackgroundColor(result);
+
+                html.AppendLine("<tr>");
+                html.AppendLine($"<td style='border: 1px solid lightgray; padding: 8px;{background}'>{result}</td>");
+                html.AppendLine($"<td style='border: 1px solid lightgray; padding: 8px;'>{resultCount}</td>");
+                html.AppendLine("</tr>");
+            }
+
+            // Append result summary total
+            html.AppendLine("<tr>");
+            html.AppendLine($"<td style='border: 1px solid lightgray; padding: 8px;'><b>Total</b></td>");
+            html.AppendLine($"<td style='border: 1px solid lightgray; padding: 8px;'><b>{logs.Count}</b></td>");
+            html.AppendLine("</tr>");
+            html.AppendLine("</table>");
+
+            // Append log content
+            count = 0;
+            foreach (var log in logs)
+            {
+                // Append horizontal break
+                html.AppendLine($"</div>");
+                html.AppendLine($"<hr />");
+                html.AppendLine("<div style='padding-left: 25px; padding-bottom: 25px;'>");
+
+                // Test name and result
+                count++;
+                html.AppendLine($"<h2 style='padding-top: 10px'><a name='test{count}'>{count}. {log.Name}</a></h2>");
+                html.AppendLine($"<p><b>Result</b>: {log.Result}</p>");
+                html.AppendLine("<table style='border: 1px solid lightgray; border-collapse: collapse;'>");
+
+                foreach (var step in log.Steps)
+                {
+                    // Step name
+                    html.AppendLine("<tr><td style='border: 1px solid lightgray; padding: 10px'>");
+                    html.AppendLine($"<h3>{step.Name}</h3>");
+                    html.AppendLine("<div style='padding-left: 10px; padding-right: 10px; padding-bottom: 10px'>");
+
+                    // Step messages
+                    html.AppendLine("<h4>Messages</h4>");
+                    html.AppendLine("<div style='margin-left: 20px; margin-right: 20px; background-color: #F0F0F0'>");
+                    html.AppendLine("<pre>");
+                    foreach (var message in step.Messages)
+                    {
+                        html.AppendLine(message);
+                    }
+                    html.AppendLine("</pre>");
+                    html.AppendLine("</div>");
+
+                    // Step artifacts (other than screenshots)
+                    var types = step.Artifacts.Keys.Where(t => t != ArtifactTypes.Screenshots);
+                    if (types.Any())
+                    {
+                        html.AppendLine("<h4>Artifacts</h4>");
+                        html.AppendLine("<div style='margin-left: 20px; margin-right: 20px'>");
+                        foreach (var type in types)
+                        {
+                            html.AppendLine($"<p>{type}:</p>");
+                            html.AppendLine("<ol>");
+                            foreach (var artifact in step.Artifacts[type])
+                            {
+                                string artifactUri = ConvertPath(artifact, relativePath);
+                                html.AppendLine($"<li><a href='{artifactUri}' target='_blank'/>{Path.GetFileName(artifact)}</a></li>");
+                            }
+                            html.AppendLine("</ol>");
+                        }
+                        html.AppendLine("</div>");
+                    }
+
+                    // Step screenshots
+                    if (step.Artifacts.ContainsKey(ArtifactTypes.Screenshots))
+                    {
+                        html.AppendLine($"<h4>{ArtifactTypes.Screenshots}</h4>");
+                        foreach (var screenshot in step.Artifacts[ArtifactTypes.Screenshots])
+                        {
+                            string screenshotUri = ConvertPath(screenshot, relativePath);
+                            html.AppendLine($"<div><a href='{screenshotUri}' target='_blank'><img src='{screenshotUri}' style='border: 1px solid #555; max-width:{maxScreenshotWidth}px'/></a></div>");
+                        }
+                    }
+
+                    html.AppendLine("</div>");
+                    html.AppendLine("</td></tr>");
+                }
+
+                html.AppendLine("</table>");
+            }
+
+            // Append HTML doc closer
+            html.AppendLine("</div>");
+            html.AppendLine($"<hr />");
+            html.AppendLine("</div>");
+            html.AppendLine("</body>");
+            html.AppendLine("</html>");
+
+            // Get the path for the file
+            string path = GetDumpFilePath(HtmlExtension);
+
+            // Write the file
+            File.WriteAllText(path, html.ToString());
+
+            // Return the path to the file
+            return path;
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor/Dumping/Dumpers/TestLogReportDumper.cs
+++ b/Boa.Constrictor/Dumping/Dumpers/TestLogReportDumper.cs
@@ -115,7 +115,7 @@ namespace Boa.Constrictor.Dumping
 
         /// <summary>
         /// Writes the HTML report using the given TestLogData objects.
-        /// Returns the report file's file's path.
+        /// Returns the report file's file path.
         /// </summary>
         /// <param name="logs">A list of log data objects.</param>
         /// <param name="relativePath">If provided, overwrites artifact absolute paths with this relative path.</param>

--- a/Boa.Constrictor/Dumping/Parents/AbstractDumper.cs
+++ b/Boa.Constrictor/Dumping/Parents/AbstractDumper.cs
@@ -36,6 +36,11 @@ namespace Boa.Constrictor.Dumping
         }
 
         /// <summary>
+        /// The token for the file name.
+        /// </summary>
+        public string FileToken { get; private set; }
+
+        /// <summary>
         /// A descriptive name for the dumper.
         /// </summary>
         public string Name { get; private set; }
@@ -49,10 +54,12 @@ namespace Boa.Constrictor.Dumping
         /// </summary>
         /// <param name="name">A descriptive name for the dumper.</param>
         /// <param name="dumpDir">The output directory for dumped files.</param>
-        public AbstractDumper(string name, string dumpDir)
+        /// <param name="fileToken">The token for the file name.</param>
+        public AbstractDumper(string name, string dumpDir, string fileToken)
         {
             Name = name;
             DumpDir = dumpDir;
+            FileToken = fileToken;
         }
 
         #endregion
@@ -62,13 +69,12 @@ namespace Boa.Constrictor.Dumping
         /// <summary>
         /// Concatenates the dump file path.
         /// </summary>
-        /// <param name="token">The token name for the file.</param>
         /// <param name="extension">The file extension. (blank by default)</param>
         /// <param name="suffix">An optional suffix for the filename.</param>
         /// <returns></returns>
-        protected string GetDumpFilePath(string token, string extension = "", string suffix = null)
+        protected string GetDumpFilePath(string extension = "", string suffix = null)
         {
-            string name = Names.ConcatUniqueName(token, suffix) + extension;
+            string name = Names.ConcatUniqueName(FileToken, suffix) + extension;
             string path = Path.Combine(DumpDir, name);
 
             return path;

--- a/Boa.Constrictor/Logging/Models/ArtifactTypes.cs
+++ b/Boa.Constrictor/Logging/Models/ArtifactTypes.cs
@@ -20,5 +20,15 @@
         /// Artifact type for screenshot images.
         /// </summary>
         public const string Screenshots = "Screenshots";
+
+        /// <summary>
+        /// Artifact type for test log reports.
+        /// </summary>
+        public const string TestLogReports = "TestLogReports";
+
+        /// <summary>
+        /// Artifact type for test logs.
+        /// </summary>
+        public const string TestLogs = "TestLogs";
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.8.2] - 2021-01-11
+
+### Added
+
+- Added `TestLogReportDumper` to combine `TestLogData` objects into one pretty HTML report
+- Refactored `AbstractDumper` to share more parts
+
+
 ## [0.8.1] - 2021-01-07
 
 ### Changed


### PR DESCRIPTION
`TestLogReportDumper` combines `TestLogData` objects into one pretty HTML report.

This change also contains an update to version **0.8.2**.