### PR TITLE
Added .NET 5.0 targets

### DIFF
--- a/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
+++ b/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Boa.Constrictor.UnitTests/Boa.Constrictor.UnitTests.csproj
+++ b/Boa.Constrictor.UnitTests/Boa.Constrictor.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
-    <Version>0.8.3</Version>
+    <Version>0.9.0</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Version>0.8.3</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.9.0] - 2021-01-15
+
+### Added
+
+- Added .NET 5 support!
+  - `Boa.Constrictor` targets both .NET 5 and .NET Standard 2.0
+  - `Boa.Constrictor.Example` targets .NET 5 exclusively
+  - `Boa.Constrictor.UnitTests` targets .NET 5 exclusively
+
+
 ## [0.8.3] - 2021-01-13
 
 ### Fixed


### PR DESCRIPTION
This change adds .NET 5 support to Boa Constrictor. It also bumps the version to **0.9.0**.

Here's how each .NET project is updated:
- `Boa.Constrictor` adds the `net5.0` target while keeping `netstandard2.0` (in order to continue supporting .NET Framework and .NET Core)
- `Boa.Constrictor.Example` and `Boa.Constrictor.UnitTests` have changed target from `netcoreapp3.1` to `net5.0`

I was able to successfully build and run the tests for the solution on my local machine:
![image](https://user-images.githubusercontent.com/61242579/104674548-d5236980-56b1-11eb-8845-d149fb94fa47.png)

It looks like the GitHub Actions for the repository did _not_ need any changes in order to work. The actions triggered by this pull request passed.

The work for the .NET 5 update was trailblazed by https://github.com/sparky2471 in #52. Many thanks!