### PR TITLE
Enabled RestClient object to be directly injectable into RestSharp Abilities

### DIFF
--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
-    <Version>0.11.1</Version>
+    <Version>0.11.2</Version>
     <Authors>Andrew "Pandy" Knight,Andrew Williams,Steve Hernandez</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/RestSharp/Abilities/AbstractRestSharpAbility.cs
+++ b/Boa.Constrictor/RestSharp/Abilities/AbstractRestSharpAbility.cs
@@ -1,6 +1,5 @@
 ﻿using Boa.Constrictor.Dumping;
 using RestSharp;
-using System;
 using System.Net;
 
 namespace Boa.Constrictor.RestSharp
@@ -25,21 +24,28 @@ namespace Boa.Constrictor.RestSharp
         #region Constructors
 
         /// <summary>
-        /// Private constructor.
-        /// (Use the static methods for public construction.)
+        /// Protected constructor.
+        /// (Use static methods in a subclass for public construction.)
         /// </summary>
-        /// <param name="baseUrl">The base URL for the RestSharp client.</param>
-        protected AbstractRestSharpAbility(string baseUrl)
+        /// <param name="client">The RestSharp client.</param>
+        protected AbstractRestSharpAbility(IRestClient client)
         {
-            Client = new RestClient()
-            {
-                BaseUrl = new Uri(baseUrl),
-                CookieContainer = new CookieContainer()
-            };
-
+            Client = client;
             RequestDumper = null;
             DownloadDumper = null;
+
+            if (Client.CookieContainer == null)
+                Client.CookieContainer = new CookieContainer();
         }
+
+        /// <summary>
+        /// Protected constructor.
+        /// (Use static methods in a subclass for public construction.)
+        /// </summary>
+        /// <param name="baseUrl">The base URL for the RestSharp client.</param>
+        protected AbstractRestSharpAbility(string baseUrl) :
+            this(new RestClient(baseUrl))
+        { }
 
         #endregion
 

--- a/Boa.Constrictor/RestSharp/Abilities/CallRestApi.cs
+++ b/Boa.Constrictor/RestSharp/Abilities/CallRestApi.cs
@@ -1,4 +1,5 @@
 ﻿using Boa.Constrictor.Dumping;
+using RestSharp;
 
 namespace Boa.Constrictor.RestSharp
 {
@@ -23,8 +24,15 @@ namespace Boa.Constrictor.RestSharp
         #region Constructors
 
         /// <summary>
-        /// Private constructor.
-        /// (Use the static methods for public construction.)
+        /// Protected constructor.
+        /// (Use static builder methods for public construction.)
+        /// </summary>
+        /// <param name="client">The RestSharp client.</param>
+        protected CallRestApi(IRestClient client) : base(client) { }
+
+        /// <summary>
+        /// Protected constructor.
+        /// (Use static builder methods for public construction.)
         /// </summary>
         /// <param name="baseUrl">The base URL for the RestSharp client.</param>
         protected CallRestApi(string baseUrl) : base(baseUrl) { }
@@ -39,6 +47,13 @@ namespace Boa.Constrictor.RestSharp
         /// <param name="baseUrl">The base URL for the RestSharp client.</param>
         /// <returns></returns>
         public static CallRestApi At(string baseUrl) => new CallRestApi(baseUrl);
+
+        /// <summary>
+        /// Constructs this ability.
+        /// </summary>
+        /// <param name="client">The RestSharp client.</param>
+        /// <returns></returns>
+        public static CallRestApi Using(IRestClient client) => new CallRestApi(client);
 
         /// <summary>
         /// Sets the ability to dump requests/responses to the given path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [0.11.2] - 2021-02-22
+
+### Changed
+
+- Enabled `IRestClient` objects to be directly injectable into `AbstractRestSharpAbility` and its child classes
+
+
 ## [0.11.1] - 2021-02-08
 
 ### Changed


### PR DESCRIPTION
This change updates the version to `0.11.2`.