### PR TITLE
Updated github-pages to 214

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -13,13 +13,13 @@ source "https://rubygems.org"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
-gem "github-pages", "~> 213", group: :jekyll_plugins
+gem "github-pages", "~> 214", group: :jekyll_plugins
 gem "jekyll-seo-tag", group: :jekyll_plugins
 gem "jekyll-include-cache", group: :jekyll_plugins
 gem "jekyll-remote-theme", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.15.1"
+  gem "jekyll-feed"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     ffi (1.15.0-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (213)
+    github-pages (214)
       github-pages-health-check (= 1.17.0)
       jekyll (= 3.9.0)
       jekyll-avatar (= 0.7.0)
@@ -70,7 +70,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.3)
       jemoji (= 0.12.0)
-      kramdown (= 2.3.0)
+      kramdown (= 2.3.1)
       kramdown-parser-gfm (= 1.1.0)
       liquid (= 4.0.3)
       mercenary (~> 0.3)
@@ -198,12 +198,12 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.5.0)
+    listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
@@ -225,7 +225,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (3.26.0)
     ruby-enum (0.9.0)
       i18n
@@ -262,8 +262,8 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
-  github-pages (~> 213)
-  jekyll-feed (~> 0.15.1)
+  github-pages (~> 214)
+  jekyll-feed
   jekyll-include-cache
   jekyll-remote-theme
   jekyll-seo-tag


### PR DESCRIPTION
Updating `github-pages` to 214 also updates `kramdown` to 2.3.1, which fixes a security vulnerability.

I tested the doc site locally, and it works.

GitHub Pages supports this new version: https://pages.github.com/versions/