### PR TITLE
Set the Boa Constrictor logo as the NuGet package icon

### DIFF
--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -42,8 +42,7 @@ jobs:
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
 
           # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          # Commenting this out due to https://github.com/brandedoutcast/publish-nuget/issues/58#issuecomment-825194931
-          # NUGET_SOURCE: https://api.nuget.org
+          NUGET_SOURCE: https://api.nuget.org
 
           # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
           INCLUDE_SYMBOLS: true

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
-    <Version>0.13.1-alpha1</Version>
+    <Version>0.13.1-alpha2</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>
@@ -14,6 +14,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageReleaseNotes>Please read https://github.com/q2ebanking/boa-constrictor/blob/main/CHANGELOG.md for full release notes.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -25,6 +26,7 @@
     <PackageReference Include="RestSharp" Version="106.11.7" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <None Include="../docs/assets/images/logos/logo-symbol-black-120x148.png" Pack="true" PackagePath="$(PackageIcon)" />
     <None Include="../LICENSE.md" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
-## [0.13.1-alpha1] - 2021-04-22
+## [0.13.1-alpha2] - 2021-04-22
+
+### Added
+
+- Set project icon to the new Boa Constrictor logo
 
 ### Fixed
 
 - Attempted to fix error message in `nuget-push.yml` GitHub Action
+- Undid that attempt because it didn't work
 
 
 ## [0.13.0] - 2021-04-22


### PR DESCRIPTION
This bumps the version to `0.13.1-alpha2`. This package undoes the changes from alpha1 (because they didn't work) and attempts to set the NuGet package icon to the Boa Constrictor logo.