### PR TITLE
Added ChangeWebDriver Task

### DIFF
--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
-    <Version>0.13.1</Version>
+    <Version>0.14.0</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor/WebDriver/Abilities/BrowseTheWeb.cs
+++ b/Boa.Constrictor/WebDriver/Abilities/BrowseTheWeb.cs
@@ -30,7 +30,7 @@ namespace Boa.Constrictor.WebDriver
         /// <summary>
         /// The WebDriver instance.
         /// </summary>
-        public IWebDriver WebDriver { get; }
+        public IWebDriver WebDriver { get; internal set; }
 
         /// <summary>
         /// The collection of stored browser window handles.

--- a/Boa.Constrictor/WebDriver/Tasks/ChangeWebDriver.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/ChangeWebDriver.cs
@@ -1,0 +1,105 @@
+﻿using Boa.Constrictor.Screenplay;
+using OpenQA.Selenium;
+using System;
+
+namespace Boa.Constrictor.WebDriver
+{
+    /// <summary>
+    /// Changes the WebDriver instance in the Actor's BrowseTheWeb Ability.
+    /// Sometimes, WebDriver instances can arbitrarily fail due to problems with the tool, not the web app under test.
+    /// This Task enables the Actor to "recover" by providing it with a new WebDriver instance.
+    /// 
+    /// USE THIS TASK WITH CAUTION!
+    /// Changing the WebDriver instance could be dangerous.
+    /// Make sure to quit the old WebDriver first.
+    /// Also make sure that automation can continue after the WebDriver change.
+    /// </summary>
+    public class ChangeWebDriver : AbstractWebTask
+    {
+        #region Properties
+
+        /// <summary>
+        /// The new WebDriver instance.
+        /// </summary>
+        public IWebDriver NewDriver { get; }
+
+        /// <summary>
+        /// If true, attempt to quit the old WebDriver instance before replacing it.
+        /// </summary>
+        public bool QuitOldDriver { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Private constructor.
+        /// (Use public builder methods instead.)
+        /// </summary>
+        /// <param name="newDriver">The new WebDriver instance.</param>
+        /// <param name="quitOldDriver">If true, attempt to quit the old WebDriver instance before replacing it.</param>
+        private ChangeWebDriver(IWebDriver newDriver, bool quitOldDriver = false)
+        {
+            NewDriver = newDriver;
+            QuitOldDriver = quitOldDriver;
+        }
+
+        #endregion
+
+        #region Builder Methods
+
+        /// <summary>
+        /// Creates the Task.
+        /// </summary>
+        /// <returns></returns>
+        public static ChangeWebDriver To(IWebDriver newDriver) => new ChangeWebDriver(newDriver);
+        
+        /// <summary>
+        /// Forces this Task to quit the old WebDriver instance before changing to the new one.
+        /// </summary>
+        /// <returns></returns>
+        public ChangeWebDriver AfterQuittingOldWebDriver()
+        {
+            QuitOldDriver = true;
+            return this;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Refreshes the browser.
+        /// </summary>
+        /// <param name="actor">The Screenplay actor.</param>
+        /// <param name="driver">The WebDriver.</param>
+        public override void PerformAs(IActor actor, IWebDriver driver)
+        {
+            if (QuitOldDriver)
+            {
+                actor.Logger.Info("Attempting to quit the current WebDriver instance");
+
+                try
+                {
+                    actor.AttemptsTo(QuitWebDriver.ForBrowser());
+                }
+                catch (Exception e)
+                {
+                    actor.Logger.Warning("Failed to quit the current WebDriver instance");
+                    actor.Logger.Warning(e.Message);
+                }
+            }
+
+            actor.Logger.Info("Setting the new WebDriver instance in the Actor's BrowseTheWeb Ability");
+            actor.Using<BrowseTheWeb>().WebDriver = NewDriver;
+        }
+
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"Change the WebDriver instance to a new {NewDriver.GetType()}";
+
+        #endregion
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `ChangeWebDriver` Task for changing `BrowseTheWeb`'s WebDriver
 - Added more Boa Constrictor logo assets under the `logos` directory
 - Added Boa Constrictor PowerPoint master slide deck
 - Added Boa Constrictor talk slides and script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+(None)
+
+
+## [0.14.0] - 2021-05-14
+
 ### Added
 
 - Added `ChangeWebDriver` Task for changing `BrowseTheWeb`'s WebDriver


### PR DESCRIPTION
`ChangeWebDriver` changes `BrowseTheWeb`'s WebDriver instance.

- Tested locally by hacking the Example project
- Comments include warnings about the dangers
- The Task may optionally quit the old WebDriver
- `BrowseTheWeb`'s `WebDriver` property uses `internal set` to prevent other callers from setting it directly

This change also bumps the version to 0.14.0.