### PR TITLE
Multi task AttemptsTo

### DIFF
--- a/Boa.Constrictor.UnitTests/Screenplay/Pattern/ActorTest.cs
+++ b/Boa.Constrictor.UnitTests/Screenplay/Pattern/ActorTest.cs
@@ -97,6 +97,17 @@ namespace Boa.Constrictor.UnitTests.Screenplay
         }
 
         [Test]
+        public void AttemptsToPerformMultipleTasks()
+        {
+            int performCount = 0;
+            var MockTask = new Mock<ITask>();
+            MockTask.Setup(x => x.PerformAs(It.IsAny<IActor>())).Callback((IActor actor) => performCount++).Verifiable();
+            ITask[] tasks = new ITask[] { MockTask.Object, MockTask.Object, MockTask.Object };
+            new Actor().AttemptsTo(tasks);
+            performCount.Should().Be(tasks.Length);
+        }
+
+        [Test]
         public void CallsTask()
         {
             bool performed = false;

--- a/Boa.Constrictor/Screenplay/Pattern/Actor.cs
+++ b/Boa.Constrictor/Screenplay/Pattern/Actor.cs
@@ -97,6 +97,19 @@ namespace Boa.Constrictor.Screenplay
         }
 
         /// <summary>
+        /// Performs multiple tasks
+        /// The actor must have the abilities needed by the task(s).
+        /// </summary>
+        /// <param name="tasks">The tasks to perform.</param>
+        public void AttemptsTo(params ITask[] tasks)
+        {
+            foreach(ITask task in tasks)
+            {
+                AttemptsTo(task);
+            }
+        }
+
+        /// <summary>
         /// Asks a question and returns the answer value.
         /// The actor must have the abilities needed by the question.
         /// </summary>

--- a/Boa.Constrictor/Screenplay/Pattern/IActor.cs
+++ b/Boa.Constrictor/Screenplay/Pattern/IActor.cs
@@ -49,6 +49,13 @@ namespace Boa.Constrictor.Screenplay
         void AttemptsTo(ITask task);
 
         /// <summary>
+        /// Performs multiple tasks
+        /// The actor must have the abilities needed by the task(s).
+        /// </summary>
+        /// <param name="tasks">The tasks to perform.</param>
+        void AttemptsTo(params ITask[] tasks);
+
+        /// <summary>
         /// Asks a question and returns the answer value.
         /// The actor must have the abilities needed by the question.
         /// </summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added overload for AttemptsTo that accepts multiple tasks
+
 ### Changed
 
 - Updated AbstractComparison constructor to protected


### PR DESCRIPTION
See #107 

Adds an overload to `AttemptsTo` that accepts multiple tasks. This provides a simpler syntax than the existing `RunTasks` task

I felt this change warranted a unit test. I'm not very familiar with Moq so if you feel there is a better way to perform the test then I will gladly change it.