### PR TITLE
Boa Constrictor 1.2.1-alpha (nuget-push.yml fix, Gemfile security update)

### DIFF
--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -43,6 +43,3 @@ jobs:
 
           # NuGet server uri hosting the packages, defaults to https://api.nuget.org
           NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          INCLUDE_SYMBOLS: true

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
-    <Version>1.2.0</Version>
+    <Version>1.2.1-alpha</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
+## [1.2.1-alpha] - 2021-07-14
+
+### Fixed
+
+- Removed `INCLUDE_SYMBOLS` from `nuget-push.yml` to fix NuGet publishing error
+  - See https://github.com/brandedoutcast/publish-nuget/pull/62#issuecomment-860327648
+
+
 ## [1.2.0] - 2021-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `INCLUDE_SYMBOLS` from `nuget-push.yml` to fix NuGet publishing error
   - See https://github.com/brandedoutcast/publish-nuget/pull/62#issuecomment-860327648
+- Gemfile: required `addressable >= 2.8.0` to fix security vulnerability
 
 
 ## [1.2.0] - 2021-06-10

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -14,6 +14,7 @@ source "https://rubygems.org"
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
 gem "github-pages", "~> 215", group: :jekyll_plugins
+gem "addressable", ">= 2.8.0"
 gem "jekyll-seo-tag", group: :jekyll_plugins
 gem "jekyll-include-cache", group: :jekyll_plugins
 gem "jekyll-remote-theme", group: :jekyll_plugins

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.7)
+    activesupport (6.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     coffee-script (2.4.1)
       coffee-script-source
@@ -16,8 +16,8 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.8)
-    dnsruby (1.61.5)
+    concurrent-ruby (1.1.9)
+    dnsruby (1.61.7)
       simpleidn (~> 0.1)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
@@ -26,20 +26,24 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.8.1)
-    faraday (1.4.2)
+    faraday (1.5.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
-    ffi (1.15.0-x64-mingw32)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    ffi (1.15.3-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (215)
@@ -230,7 +234,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
     racc (1.5.2)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
@@ -238,7 +242,7 @@ GEM
     ruby-enum (0.9.0)
       i18n
     ruby2_keywords (0.0.4)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -270,6 +274,7 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  addressable (>= 2.8.0)
   github-pages (~> 215)
   jekyll-feed
   jekyll-include-cache


### PR DESCRIPTION
Removed INCLUDE_SYMBOLS from nuget-push.yml. According to [this comment](https://github.com/brandedoutcast/publish-nuget/pull/62#issuecomment-860327648), this option shouldn't be necessary. We already have the `.csproj` options set.

Resolved a [Gemfile security vulnerability](https://github.com/q2ebanking/boa-constrictor/security/dependabot/docs/Gemfile.lock/addressable/open) by requiring `addressable` >= 2.8.0.

This change bumps the Boa Constrictor version to `1.2.1-alpha`. It's an alpha release to test the symbols package publishing.