### PR TITLE
Boa Constrictor 1.2.1

### DIFF
--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
-    <Version>1.2.1-alpha2</Version>
+    <Version>1.2.1</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>PrecisionLender, a Q2 Company</Company>
     <Title>Boa Constrictor</Title>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (None)
 
 
-## [1.2.1-alpha2] - 2021-07-15
+## [1.2.1] - 2021-07-15
 
 ### Fixed
 


### PR DESCRIPTION
This pull request releases Boa Constrictor 1.2.1 officially. It replaces the alpha releases.