### PR TITLE
New functionality for Wait task

### DIFF
--- a/Boa.Constrictor.UnitTests/Screenplay/Waiting/ValueAfterWaitingTest.cs
+++ b/Boa.Constrictor.UnitTests/Screenplay/Waiting/ValueAfterWaitingTest.cs
@@ -67,7 +67,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
 
             Actor.Invoking(actor => actor.AskingFor(ValueAfterWaiting.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
-                .Should().Throw<WaitingException<int>>(because: "the question should not satisfy the condition");
+                .Should().Throw<WaitingException>(because: "the question should not satisfy the condition");
         }
 
         #endregion

--- a/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitTest.cs
+++ b/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitTest.cs
@@ -15,8 +15,12 @@ namespace Boa.Constrictor.UnitTests.Screenplay
         #region Test Variables
 
         private IActor Actor { get; set; }
-        private Mock<IQuestion<int>> MockQuestion { get; set; }
-        private Mock<ICondition<int>> MockCondition { get; set; }
+        private Mock<IQuestion<int>> MockQuestionInt { get; set; }
+        private Mock<ICondition<int>> MockConditionInt { get; set; }
+        private Mock<IQuestion<bool>> MockQuestionBool { get; set; }
+        private Mock<ICondition<bool>> MockConditionBool { get; set; }
+        private Mock<IQuestion<string>> MockQuestionString { get; set; }
+        private Mock<ICondition<string>> MockConditionString { get; set; }
 
         #endregion
 
@@ -26,8 +30,12 @@ namespace Boa.Constrictor.UnitTests.Screenplay
         public void SetUp()
         {
             Actor = new Actor();
-            MockQuestion = new Mock<IQuestion<int>>();
-            MockCondition = new Mock<ICondition<int>>();
+            MockQuestionInt = new Mock<IQuestion<int>>();
+            MockConditionInt = new Mock<ICondition<int>>();
+            MockQuestionBool = new Mock<IQuestion<bool>>();
+            MockConditionBool = new Mock<ICondition<bool>>();
+            MockQuestionString = new Mock<IQuestion<string>>();
+            MockConditionString = new Mock<ICondition<string>>();
         }
 
         #endregion
@@ -37,10 +45,10 @@ namespace Boa.Constrictor.UnitTests.Screenplay
         [Test]
         public void TestSuccessfulWait()
         {
-            MockQuestion.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
-            MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(true);
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
+            MockConditionInt.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(true);
 
-            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
+            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestionInt.Object, MockConditionInt.Object).ForUpTo(0)))
                 .Should().NotThrow(because: "the question should satisfy the condition");
         }
 
@@ -50,11 +58,11 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             const int limit = 5;
             int incrementer = 0;
 
-            MockQuestion.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(() => ++incrementer);
-            MockCondition.Setup(x => x.Evaluate(It.Is<int>(v => v < limit))).Returns(false);
-            MockCondition.Setup(x => x.Evaluate(It.Is<int>(v => v >= limit))).Returns(true);
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(() => ++incrementer);
+            MockConditionInt.Setup(x => x.Evaluate(It.Is<int>(v => v < limit))).Returns(false);
+            MockConditionInt.Setup(x => x.Evaluate(It.Is<int>(v => v >= limit))).Returns(true);
 
-            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(1)))
+            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestionInt.Object, MockConditionInt.Object).ForUpTo(1)))
                 .Should().NotThrow(because: "the question should satisfy the condition");
 
             incrementer.Should().Be(limit, because: $"the question should be called {limit} times");
@@ -63,11 +71,122 @@ namespace Boa.Constrictor.UnitTests.Screenplay
         [Test]
         public void TestFailedWait()
         {
-            MockQuestion.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
-            MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
+            MockConditionInt.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
 
-            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
+            Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestionInt.Object, MockConditionInt.Object).ForUpTo(0)))
                 .Should().Throw<WaitingException>(because: "the question should not satisfy the condition");
+        }
+
+        [Test]
+        public void TestSuccessfulWaitMultipleTypesAnd()
+        {
+            //success
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
+            MockConditionInt.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(true);
+            //success
+            MockQuestionBool.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(false);
+            MockConditionBool.Setup(x => x.Evaluate(It.IsAny<bool>())).Returns(true);
+            //success
+            MockQuestionString.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns("title");
+            MockConditionString.Setup(x => x.Evaluate(It.IsAny<string>())).Returns(true);
+
+            Actor.Invoking(actor => actor.AttemptsTo(
+                Wait.Until(MockQuestionInt.Object, MockConditionInt.Object)
+                .And(MockQuestionBool.Object, MockConditionBool.Object)
+                .And(MockQuestionString.Object, MockConditionString.Object)
+                .ForUpTo(0)))
+                .Should().NotThrow(because: "the question should satisfy the condition");
+        }
+
+        [Test]
+        public void TestSuccessfulWaitMultipleTypesOr()
+        {
+            //fail
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
+            MockConditionInt.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
+            //fail
+            MockQuestionBool.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(false);
+            MockConditionBool.Setup(x => x.Evaluate(It.IsAny<bool>())).Returns(false);
+            //success
+            MockQuestionString.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns("title");
+            MockConditionString.Setup(x => x.Evaluate(It.IsAny<string>())).Returns(true);
+
+            Actor.Invoking(actor => actor.AttemptsTo(
+                Wait.Until(MockQuestionInt.Object, MockConditionInt.Object)
+                .And(MockQuestionBool.Object, MockConditionBool.Object)
+                .Or(MockQuestionString.Object, MockConditionString.Object)
+                .ForUpTo(0)))
+                .Should().NotThrow(because: "the question should satisfy the condition");
+        }
+
+        [Test]
+        public void TestFailedWaitMultipleTypesAnd()
+        {
+            //success
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
+            MockConditionInt.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(true);
+            //fail
+            MockQuestionBool.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(false);
+            MockConditionBool.Setup(x => x.Evaluate(It.IsAny<bool>())).Returns(false);
+            //success
+            MockQuestionString.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns("title");
+            MockConditionString.Setup(x => x.Evaluate(It.IsAny<string>())).Returns(true);
+
+            Actor.Invoking(actor => actor.AttemptsTo(
+                Wait.Until(MockQuestionInt.Object, MockConditionInt.Object)
+                .And(MockQuestionBool.Object, MockConditionBool.Object)
+                .And(MockQuestionString.Object, MockConditionString.Object)
+                .ForUpTo(0)))
+                .Should().Throw<WaitingException>(because: "the question should not satisfy the condition");
+        }
+
+        [Test]
+        public void TestFailedWaitMultipleTypesOr()
+        {
+            //success
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(1);
+            MockConditionInt.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(true);
+            //fail
+            MockQuestionBool.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(false);
+            MockConditionBool.Setup(x => x.Evaluate(It.IsAny<bool>())).Returns(false);
+            //fail
+            MockQuestionString.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns("title");
+            MockConditionString.Setup(x => x.Evaluate(It.IsAny<string>())).Returns(false);
+
+            Actor.Invoking(actor => actor.AttemptsTo(
+                Wait.Until(MockQuestionInt.Object, MockConditionInt.Object)
+                .And(MockQuestionBool.Object, MockConditionBool.Object)
+                .Or(MockQuestionString.Object, MockConditionString.Object)
+                .ForUpTo(0)))
+                .Should().Throw<WaitingException>(because: "the question should not satisfy the condition");
+        }
+
+        [Test]
+        public void TestSuccessfulWaitMultipleTypesAndAfterChange()
+        {
+            const int limit = 5;
+            int incrementer = 0;
+
+            //success
+            MockQuestionInt.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(() => ++incrementer);
+            MockConditionInt.Setup(x => x.Evaluate(It.Is<int>(v => v < limit))).Returns(false);
+            MockConditionInt.Setup(x => x.Evaluate(It.Is<int>(v => v >= limit))).Returns(true);
+            //success
+            MockQuestionBool.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns(false);
+            MockConditionBool.Setup(x => x.Evaluate(It.IsAny<bool>())).Returns(true);
+            //success
+            MockQuestionString.Setup(x => x.RequestAs(It.IsAny<IActor>())).Returns("title");
+            MockConditionString.Setup(x => x.Evaluate(It.IsAny<string>())).Returns(true);
+
+            Actor.Invoking(actor => actor.AttemptsTo(
+                Wait.Until(MockQuestionInt.Object, MockConditionInt.Object)
+                .And(MockQuestionBool.Object, MockConditionBool.Object)
+                .And(MockQuestionString.Object, MockConditionString.Object)
+                .ForUpTo(1)))
+                .Should().NotThrow(because: "the question should satisfy the condition");
+
+            incrementer.Should().Be(limit, because: $"the question should be called {limit} times");
         }
 
         #endregion

--- a/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitTest.cs
+++ b/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitTest.cs
@@ -67,7 +67,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
 
             Actor.Invoking(actor => actor.AttemptsTo(Wait.Until(MockQuestion.Object, MockCondition.Object).ForUpTo(0)))
-                .Should().Throw<WaitingException<int>>(because: "the question should not satisfy the condition");
+                .Should().Throw<WaitingException>(because: "the question should not satisfy the condition");
         }
 
         #endregion

--- a/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitingExtensionsTest.cs
+++ b/Boa.Constrictor.UnitTests/Screenplay/Waiting/WaitingExtensionsTest.cs
@@ -67,7 +67,7 @@ namespace Boa.Constrictor.UnitTests.Screenplay
             MockCondition.Setup(x => x.Evaluate(It.IsAny<int>())).Returns(false);
 
             Actor.Invoking(actor => actor.WaitsUntil(MockQuestion.Object, MockCondition.Object, timeout: 0))
-                .Should().Throw<WaitingException<int>>(because: "the question should not satisfy the condition");
+                .Should().Throw<WaitingException>(because: "the question should not satisfy the condition");
         }
 
         #endregion

--- a/Boa.Constrictor/Screenplay/Pattern/ConditionWrapper.cs
+++ b/Boa.Constrictor/Screenplay/Pattern/ConditionWrapper.cs
@@ -1,0 +1,83 @@
+﻿namespace Boa.Constrictor.Screenplay
+{
+    /// <summary>
+    /// This wraps a generic Question and Condition in a non-generic wrapper.
+    /// </summary>
+    /// <typeparam name="TAnswer"></typeparam>
+    public class ConditionWrapper<TAnswer> : IConditionAdaptor
+    {
+        #region Properties
+
+        /// <summary>
+        /// The IQuestion.
+        /// </summary>
+        private readonly IQuestion<TAnswer> Question;
+
+        /// <summary>
+        /// The ICondition.
+        /// </summary>
+        private readonly ICondition<TAnswer> Condition;
+
+        /// <summary>
+        /// The Answer.
+        /// </summary>
+        protected TAnswer Answer { get; set; } = default;
+
+        /// <summary>
+        /// The boolean operator associated with the pair of question and condition.
+        /// </summary>
+        public Operators Operator { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor for the wrapper.
+        /// </summary>
+        /// <param name="question"></param>
+        /// <param name="condition"></param>
+        /// <param name="boolOp"></param>
+        public ConditionWrapper(IQuestion<TAnswer> question, ICondition<TAnswer> condition, Operators boolOp = Operators.And)
+        {
+            Question = question;
+            Condition = condition;
+            Operator = boolOp;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Evalutes the Condition against the Question's answer.
+        /// </summary>
+        /// <param name="actor"></param>
+        /// <returns></returns>
+        public bool Evaluate(IActor actor)
+        {
+            Answer = actor.AsksFor(Question);
+            return Condition.Evaluate(Answer);
+        }
+
+        /// <summary>
+        /// Return the most recent Answer.
+        /// </summary>
+        /// <returns></returns>
+        public string GetAnswer()
+        {
+            return Answer.ToString();
+        }
+
+        /// <summary>
+        /// Description of Question and Condition contents.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"{Question} {Condition}";
+        }
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor/Screenplay/Pattern/ConditionWrapper.cs
+++ b/Boa.Constrictor/Screenplay/Pattern/ConditionWrapper.cs
@@ -66,7 +66,7 @@
         /// <returns></returns>
         public string GetAnswer()
         {
-            return Answer.ToString();
+            return Answer?.ToString();
         }
 
         /// <summary>

--- a/Boa.Constrictor/Screenplay/Pattern/IConditionAdaptor.cs
+++ b/Boa.Constrictor/Screenplay/Pattern/IConditionAdaptor.cs
@@ -1,0 +1,26 @@
+﻿namespace Boa.Constrictor.Screenplay
+{
+    /// <summary>
+    /// Adaptor interface for evaluating a condition.
+    /// </summary>
+    public interface IConditionAdaptor
+    {
+        /// <summary>
+        /// Boolean operator associated with the Condition.
+        /// </summary>
+        Operators Operator { get; set; }
+
+        /// <summary>
+        /// Evaluate the Condition.
+        /// </summary>
+        /// <param name="actor"></param>
+        /// <returns></returns>
+        bool Evaluate(IActor actor);
+
+        /// <summary>
+        /// Return the most recent Answer.
+        /// </summary>
+        /// <returns></returns>
+        string GetAnswer();
+    }
+}

--- a/Boa.Constrictor/Screenplay/Pattern/Operators.cs
+++ b/Boa.Constrictor/Screenplay/Pattern/Operators.cs
@@ -1,0 +1,17 @@
+﻿namespace Boa.Constrictor.Screenplay
+{
+    /// <summary>
+    /// Enumeration representing boolean operators.
+    /// </summary>
+    public enum Operators
+    {
+        /// <summary>
+        /// Represents the And operator.
+        /// </summary>
+        And,
+        /// <summary>
+        /// Represents the Or operator.
+        /// </summary>
+        Or
+    }
+}

--- a/Boa.Constrictor/Screenplay/Waiting/AbstractWait.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/AbstractWait.cs
@@ -5,7 +5,6 @@ namespace Boa.Constrictor.Screenplay
 {
     /// <summary>
     /// Waits for a desired state.
-    /// The desired state is expressed using a question and an expected condition.
     /// If the desired state does not happen within the time limit, then an exception is thrown.
     /// 
     /// If the actor has the SetTimeouts ability, then the ability will be used to calculate timeouts.

--- a/Boa.Constrictor/Screenplay/Waiting/Wait.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/Wait.cs
@@ -1,4 +1,7 @@
-﻿namespace Boa.Constrictor.Screenplay
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Boa.Constrictor.Screenplay
 {
     /// <summary>
     /// Waits for a desired state.
@@ -9,8 +12,17 @@
     /// Otherwise, DefaultTimeout will be used.
     /// </summary>
     /// <typeparam name="TAnswer">The type of the question's answer value.</typeparam>
-    public class Wait<TAnswer> : AbstractWait<TAnswer>, ITask
+    public class Wait<TAnswer> : AbstractWait, ITask
     {
+        #region Properties
+
+        /// <summary>
+        /// List of Conditions to evaluate.
+        /// </summary>
+        public List<IConditionAdaptor> ConditionList { get; protected set; }
+
+        #endregion
+
         #region Constructors
 
         /// <summary>
@@ -19,9 +31,10 @@
         /// </summary>
         /// <param name="question">The question upon whose answer to wait.</param>
         /// <param name="condition">The expected condition for which to wait.</param>
-        private Wait(IQuestion<TAnswer> question, ICondition<TAnswer> condition) :
-            base(question, condition)
-        { }
+        private Wait(IQuestion<TAnswer> question, ICondition<TAnswer> condition) : base()
+        {
+            ConditionList = new List<IConditionAdaptor> { new ConditionWrapper<TAnswer>(question, condition) };
+        }
 
         #endregion
 
@@ -70,6 +83,34 @@
             return this;
         }
 
+        /// <summary>
+        /// Add a question and condition pair to the list of conditions to be evaluated with an And operator.
+        /// </summary>
+        /// <typeparam name="TOtherAnswer"></typeparam>
+        /// <param name="question"></param>
+        /// <param name="condition"></param>
+        /// <returns></returns>
+        public Wait<TAnswer> And<TOtherAnswer>(IQuestion<TOtherAnswer> question, ICondition<TOtherAnswer> condition)
+        {
+            ConditionList.Add(new ConditionWrapper<TOtherAnswer>(question, condition, Operators.And));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Add a question and condition pair to the list of conditions to be evaluated with an Or operator.
+        /// </summary>
+        /// <typeparam name="TOtherAnswer"></typeparam>
+        /// <param name="question"></param>
+        /// <param name="condition"></param>
+        /// <returns></returns>
+        public Wait<TAnswer> Or<TOtherAnswer>(IQuestion<TOtherAnswer> question, ICondition<TOtherAnswer> condition)
+        {
+            ConditionList.Add(new ConditionWrapper<TOtherAnswer>(question, condition, Operators.Or));
+
+            return this;
+        }
+
         #endregion
 
         #region Methods
@@ -81,6 +122,84 @@
         /// <param name="actor">The actor.</param>
         /// <returns></returns>
         public void PerformAs(IActor actor) => WaitForValue(actor);
+
+        /// <summary>
+        /// Separate sequential list of Conditions into groups of Conditions by Or operators.
+        /// </summary>
+        /// <returns></returns>
+        protected List<List<IConditionAdaptor>> ParseConditionGroups()
+        {
+            var groups = new List<List<IConditionAdaptor>>
+                { new List<IConditionAdaptor>() };
+
+            foreach (var pair in ConditionList)
+            {
+                if (pair.Operator == Operators.Or)
+                    groups.Add(new List<IConditionAdaptor>());
+
+                groups.Last().Add(pair);
+            }
+
+            return groups;
+        }
+
+        /// <summary>
+        /// Evaluate the conditions.
+        /// </summary>
+        /// <param name="actor">The actor.</param>
+        /// <returns></returns>
+        protected override bool EvaluateCondition(IActor actor)
+        {
+            var groups = ParseConditionGroups();
+
+            foreach (var group in groups)
+            {
+                bool satisfied = true;
+
+                foreach (var condition in group)
+                {
+                    if (!condition.Evaluate(actor))
+                    {
+                        satisfied = false;
+                        break;
+                    }
+                }
+
+                if (satisfied)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Throw the waiting exception if condition is not satisfied
+        /// </summary>
+        protected override void ThrowWaitException()
+        {
+            throw new WaitingException(this, string.Join(", ", ConditionList.Select(c => c.GetAnswer())));
+        }
+
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            string s = $"Wait until {ConditionList[0]}";
+
+            for (int i = 1; i < ConditionList.Count; i++)
+            {
+                s += $" {ConditionList[i].Operator} {ConditionList[i]}";
+            }
+
+            if (ActualTimeout >= 0)
+                s += $" for up to {ActualTimeout}s";
+            else if (TimeoutSeconds != null)
+                s += $" for up to {TimeoutSeconds + AdditionalSeconds}s";
+
+            return s;
+        }
 
         #endregion
     }

--- a/Boa.Constrictor/Screenplay/Waiting/Wait.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/Wait.cs
@@ -5,7 +5,7 @@ namespace Boa.Constrictor.Screenplay
 {
     /// <summary>
     /// Waits for a desired state.
-    /// The desired state is expressed using a question and an expected condition.
+    /// The desired state is expressed using pairs of questions and expected conditions.
     /// If the desired state does not happen within the time limit, then an exception is thrown.
     /// 
     /// If the actor has the SetTimeouts ability, then the ability will be used to calculate timeouts.

--- a/Boa.Constrictor/Screenplay/Waiting/WaitingException.cs
+++ b/Boa.Constrictor/Screenplay/Waiting/WaitingException.cs
@@ -4,8 +4,7 @@
     /// This exception should be thrown when the Wait interaction fails to meet its expected condition.
     /// It provides attributes for the actual value, the question, and the condition.
     /// </summary>
-    /// <typeparam name="TAnswer">The type of the question's answer value.</typeparam>
-    public class WaitingException<TAnswer> : ScreenplayException
+    public class WaitingException : ScreenplayException
     {
         #region Constructors
 
@@ -15,11 +14,11 @@
         /// <param name="message">The exception message.</param>
         /// <param name="interaction">The waiting interaction.</param>
         /// <param name="actual">The actual value received after waiting.</param>
-        private WaitingException(string message, AbstractWait<TAnswer> interaction, TAnswer actual) :
+        private WaitingException(string message, AbstractWait interaction, string actual) :
             base(message)
         {
             Interaction = interaction;
-            ActualValue = actual;
+            Value = actual;
         }
 
         /// <summary>
@@ -27,7 +26,7 @@
         /// </summary>
         /// <param name="interaction">The waiting interaction.</param>
         /// <param name="actual">The actual value received after waiting.</param>
-        public WaitingException(AbstractWait<TAnswer> interaction, TAnswer actual) :
+        public WaitingException(AbstractWait interaction, string actual) :
             this($"{interaction} timed out yielding '{actual}'", interaction, actual)
         { }
 
@@ -38,12 +37,12 @@
         /// <summary>
         /// The actual value received after waiting.
         /// </summary>
-        public TAnswer ActualValue { get; }
+        public string Value { get; }
 
         /// <summary>
         /// The waiting interaction.
         /// </summary>
-        public AbstractWait<TAnswer> Interaction { get; }
+        public AbstractWait Interaction { get; }
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Questions/BrowserCookie.cs
+++ b/Boa.Constrictor/WebDriver/Questions/BrowserCookie.cs
@@ -59,7 +59,7 @@ namespace Boa.Constrictor.WebDriver
                 // Wait for the cookie to exist
                 actor.WaitsUntil(BrowserCookieExistence.Named(CookieName), IsEqualTo.True());
             }
-            catch (WaitingException<bool> e)
+            catch (WaitingException e)
             {
                 // Get the cookies that actually exist
                 var cookies = driver.Manage().Cookies.AllCookies;

--- a/Boa.Constrictor/WebDriver/Tasks/WaitAndRefresh.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/WaitAndRefresh.cs
@@ -113,7 +113,7 @@ namespace Boa.Constrictor.WebDriver
                 // This page notoriously takes longer to load than others
                 actor.AttemptsTo(wait);
             }
-            catch (WaitingException<bool>)
+            catch (WaitingException)
             {
                 // If the button doesn't load, refresh the browser and retry
                 // That's what a human would do


### PR DESCRIPTION
This change introduces new functionality for the Wait task:

- Wait can take multiple pairs of IQuestion/ICondition
- The pairs are not limited to the original Wait generic type
- Pairs can be added with AND/OR boolean logic