### PR TITLE
Refactor/standardize to string methods for tasks

### DIFF
--- a/Boa.Constrictor/WebDriver/Tasks/AcceptAlert.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/AcceptAlert.cs
@@ -89,7 +89,7 @@ namespace Boa.Constrictor.WebDriver
         public override string ToString()
         {
             string exists = RethrowNoAlert ? "that must exist" : "if it exists";
-            return $"Accept browser alert {exists}";
+            return $"accept browser alert {exists}";
         }
 
         #endregion

--- a/Boa.Constrictor/WebDriver/Tasks/AddBrowserCookie.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/AddBrowserCookie.cs
@@ -93,7 +93,7 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Add a cookie named {Cookie.Name} to the browser";
+        public override string ToString() => $"add a cookie named '{Cookie.Name}' to the browser";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/ChangeWebDriver.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/ChangeWebDriver.cs
@@ -98,7 +98,8 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Change the WebDriver instance to a new {NewDriver.GetType()}";
+        public override string ToString() =>
+            $"change the WebDriver instance to a new '{NewDriver.GetType()}'";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/Check.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Check.cs
@@ -1,6 +1,5 @@
 ﻿using Boa.Constrictor.Screenplay;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Interactions;
 
 namespace Boa.Constrictor.WebDriver
 {
@@ -26,10 +25,12 @@ namespace Boa.Constrictor.WebDriver
         #endregion
 
         #region Properties
+
         /// <summary>
         /// Flag indicating if the target element should be checked or unchecked
         /// </summary>
         private bool CheckState { get; set; }
+
         #endregion
 
         #region Builder Methods
@@ -64,6 +65,16 @@ namespace Boa.Constrictor.WebDriver
             bool selectedState = actor.AsksFor(SelectedState.Of(Locator));
 
             if (selectedState != CheckState) actor.AttemptsTo(Click.On(Locator));
+        }
+
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var action = CheckState == true ? "on" : "off";
+            return $" check {action} {Locator.Description}";
         }
 
         #endregion

--- a/Boa.Constrictor/WebDriver/Tasks/Clear.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Clear.cs
@@ -43,6 +43,12 @@ namespace Boa.Constrictor.WebDriver
             driver.FindElement(Locator.Query).Clear();
         }
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"clear the text of '{Locator.Description}'";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/Click.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Click.cs
@@ -45,6 +45,12 @@ namespace Boa.Constrictor.WebDriver
             new Actions(driver).MoveToElement(driver.FindElement(Locator.Query)).Click().Perform();
         }
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"click on '{Locator.Description}'";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/DoubleClick.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/DoubleClick.cs
@@ -45,6 +45,12 @@ namespace Boa.Constrictor.WebDriver
             new Actions(driver).MoveToElement(driver.FindElement(Locator.Query)).DoubleClick().Perform();
         }
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"double-click on '{Locator.Description}'";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/Drag.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Drag.cs
@@ -63,7 +63,7 @@ namespace Boa.Constrictor.WebDriver
         /// </summary>
         /// <returns></returns>
         public override string ToString() =>
-            $"drag the mouse from '{Locator.Description}' to {Target.Description}";
+            $"drag the mouse from '{Locator.Description}' to '{Target.Description}'";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/Drag.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Drag.cs
@@ -58,6 +58,13 @@ namespace Boa.Constrictor.WebDriver
             new Actions(driver).DragAndDrop(driver.FindElement(Locator.Query), driver.FindElement(Target.Query)).Perform();
         }
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() =>
+            $"drag the mouse from '{Locator.Description}' to {Target.Description}";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/Hover.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Hover.cs
@@ -45,6 +45,12 @@ namespace Boa.Constrictor.WebDriver
             new Actions(driver).MoveToElement(driver.FindElement(Locator.Query)).Perform();
         }
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"hover over '{Locator.Description}'";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/JavaScriptClick.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/JavaScriptClick.cs
@@ -43,6 +43,12 @@ namespace Boa.Constrictor.WebDriver
         public override void PerformAs(IActor actor, IWebDriver driver) =>
             actor.Calls(JavaScript.On(Locator, "arguments[0].click();"));
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"use JavaScript to click on '{Locator.Description}'";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/MaximizeWindow.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/MaximizeWindow.cs
@@ -39,7 +39,7 @@ namespace Boa.Constrictor.WebDriver
             driver.Manage().Window.Maximize();
 
         /// <summary>
-        /// Returns a description of the question.
+        /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
         public override string ToString() => "maximize browser window";

--- a/Boa.Constrictor/WebDriver/Tasks/MaximizeWindow.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/MaximizeWindow.cs
@@ -42,7 +42,7 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the question.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Maximize browser window";
+        public override string ToString() => "maximize browser window";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/Navigate.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Navigate.cs
@@ -67,7 +67,7 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Navigate browser to '{Url}'";
+        public override string ToString() => $"navigate browser to '{Url}'";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/NavigateIfNew.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/NavigateIfNew.cs
@@ -114,7 +114,7 @@ namespace Boa.Constrictor.WebDriver
             HashCode.Combine(GetType(), Url, Acceptable.ToString(), AcceptAlerts);
 
         /// <summary>
-        /// Returns a description of the question.
+        /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
         public override string ToString()

--- a/Boa.Constrictor/WebDriver/Tasks/NavigateIfNew.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/NavigateIfNew.cs
@@ -119,7 +119,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string ToString()
         {
-            string message = $"Navigate browser to '{Url}' if not '{Acceptable}'";
+            string message = $"navigate browser to '{Url}' if not '{Acceptable}'";
 
             if (AcceptAlerts)
                 message += " and accept any alerts";

--- a/Boa.Constrictor/WebDriver/Tasks/QuitWebDriver.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/QuitWebDriver.cs
@@ -44,7 +44,7 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the question.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Quit the WebDriver";
+        public override string ToString() => "quit the WebDriver";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/QuitWebDriver.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/QuitWebDriver.cs
@@ -41,7 +41,7 @@ namespace Boa.Constrictor.WebDriver
         public override void PerformAs(IActor actor, IWebDriver driver) => driver.Quit();
 
         /// <summary>
-        /// Returns a description of the question.
+        /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
         public override string ToString() => "quit the WebDriver";

--- a/Boa.Constrictor/WebDriver/Tasks/Refresh.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Refresh.cs
@@ -42,7 +42,7 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Refresh the Web page";
+        public override string ToString() => "refresh the web page";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/RightClick.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/RightClick.cs
@@ -45,6 +45,12 @@ namespace Boa.Constrictor.WebDriver
             new Actions(driver).MoveToElement(driver.FindElement(Locator.Query)).ContextClick().Perform();
         }
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"right-click on '{Locator.Description}'";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/ScrollContainer.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/ScrollContainer.cs
@@ -130,7 +130,7 @@ namespace Boa.Constrictor.WebDriver
         /// <returns></returns>
         public override string ToString()
         {
-            string message = $"Scroll container '{Locator.Description}' {ToStringAdjective} ";
+            string message = $"scroll container '{Locator.Description}' {ToStringAdjective} ";
 
             if (Top == null)
                 message += $"left = {Left}";

--- a/Boa.Constrictor/WebDriver/Tasks/ScrollToElement.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/ScrollToElement.cs
@@ -78,15 +78,15 @@ namespace Boa.Constrictor.WebDriver
         /// Gets a unique hash code for this interaction.
         /// </summary>
         /// <returns></returns>
-        public override int GetHashCode() => 
+        public override int GetHashCode() =>
             HashCode.Combine(GetType(), Locator, AlignToTop);
 
         /// <summary>
         /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => 
-            $"Scroll to element {ToStringAdjective} '{Locator.Description}'";
+        public override string ToString() =>
+            $"scroll to element {ToStringAdjective} '{Locator.Description}'";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/SendKeys.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/SendKeys.cs
@@ -225,14 +225,14 @@ namespace Boa.Constrictor.WebDriver
         public override string ToString()
         {
             string clearDesc = UseClearMethod ? "the 'Clear' method" : "backspaces";
-            string actionDesc = Clear ? $"Clear using {clearDesc}, then send" : "Send";
+            string actionDesc = Clear ? $"clear using {clearDesc}, then send" : "send";
             string keyDesc = Private ? "private keys" : $"keys '{Keystrokes}'";
             string fullDesc = $"{actionDesc} {keyDesc} to {Locator.Description}";
 
             if (FinalEnter)
                 fullDesc += ", then hit ENTER";
             if (FinalElement != null)
-                fullDesc += $", then click {FinalElement.Description}";
+                fullDesc += $", then click '{FinalElement.Description}'";
 
             return fullDesc;
         }

--- a/Boa.Constrictor/WebDriver/Tasks/SendKeys.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/SendKeys.cs
@@ -219,7 +219,7 @@ namespace Boa.Constrictor.WebDriver
             HashCode.Combine(GetType(), Locator, Clear, FinalElement, FinalEnter, Keystrokes, Private, UseClearMethod);
 
         /// <summary>
-        /// Returns a description of the question.
+        /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
         public override string ToString()

--- a/Boa.Constrictor/WebDriver/Tasks/Submit.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/Submit.cs
@@ -47,6 +47,12 @@ namespace Boa.Constrictor.WebDriver
             driver.FindElement(Locator.Query).Submit();
         }
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => "submit a form";
+
         #endregion
     }
 }

--- a/Boa.Constrictor/WebDriver/Tasks/SwitchWindow.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/SwitchWindow.cs
@@ -66,7 +66,7 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Switch browser window to '{Handle}'";
+        public override string ToString() => $"switch browser window to '{Handle}'";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/SwitchWindowToLatest.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/SwitchWindowToLatest.cs
@@ -46,7 +46,7 @@ namespace Boa.Constrictor.WebDriver
         /// Returns a description of the task.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"Switch to the latest browser window";
+        public override string ToString() => "switch to the latest browser window";
 
         #endregion
     }

--- a/Boa.Constrictor/WebDriver/Tasks/WaitAndRefresh.cs
+++ b/Boa.Constrictor/WebDriver/Tasks/WaitAndRefresh.cs
@@ -141,6 +141,22 @@ namespace Boa.Constrictor.WebDriver
         public override int GetHashCode() =>
             HashCode.Combine(GetType(), Locator, RefreshSeconds, TimeoutSeconds, AdditionalSeconds);
 
+        /// <summary>
+        /// Returns a description of the task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            string message = $"wait for '{Locator.Description}' to appear";
+
+            if (TimeoutSeconds != null)
+                message += $" for up to {TimeoutSeconds + AdditionalSeconds}s";
+
+            message += " with a refresh if necessary";
+
+            return message;
+        }
+
         #endregion
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added user guide groundwork to the doc site
 - Added documentation stating that Boa Constrictor is not limited to small-scale projects
 - Added user guide: "Testing with NUnit"
+- Added ToString methods for Tasks that didn't have them
+
+### Changed
+- Standardized existing ToString methods for Tasks
 
 
 ## [1.3.0] - 2021-09-20


### PR DESCRIPTION
This change adds ToString methods for Tasks that didn't have them as well as standardizes those methods.
- Strings should not start with a capital letter, unless it is a proper noun
- Property variables should be surrounded by single quotes. Words/phrases that are there to help with reading the sentence (like "at"/"on", etc.) should not.
- Single strings that are too long get knocked down 1 line (entire line is roughly 100+ characters)

This change also adds a few code fixes and some cleanup
- Changed `question` to  `task` in the summary description
- Removed unused using statement
- Adjusted white space