### PR TITLE
Fix typos and formatting errors

### DIFF
--- a/docs/pages/main-docs/getting-started/page-objects.md
+++ b/docs/pages/main-docs/getting-started/page-objects.md
@@ -169,7 +169,7 @@ public class AnyPage
 The code will be the same for any other click method, too.
 This is [copypasta](https://en.wikipedia.org/wiki/Copypasta),
 and it happens frequently in page objects.
-Page objects can grow to be thousands of lines long due to duplicative methods like this.
+Page objects can grow to be thousands of lines long due to duplicate methods like this.
 
 
 ## Phase 4: Page Object Inheritance

--- a/docs/pages/main-docs/getting-started/why-boa-constrictor.md
+++ b/docs/pages/main-docs/getting-started/why-boa-constrictor.md
@@ -66,7 +66,7 @@ Page objects are more of a "convention" than a true design pattern.
 Boa Constrictor's [Screenplay Pattern](https://www.infoq.com/articles/Beyond-Page-Objects-Test-Automation-Serenity-Screenplay/)
 applies [SOLID](https://en.wikipedia.org/wiki/SOLID) design principles to modeling behaviors under test.
 Boa Constrictor provides the boilerplate code for the Screenplay Pattern so testers can readily use it.
-As a result, Boa Constrictor can scale safely and maintainably for very large projects.
+As a result, Boa Constrictor can scale safely and remain maintainable for very large projects.
 Read more about [why Screenplay interactions are better than page objects]({{ "/getting-started/page-objects/" | relative_url }}).
 
 Boa Constrictor is **not limited to small-scale projects**.

--- a/docs/pages/main-docs/project/backstory.md
+++ b/docs/pages/main-docs/project/backstory.md
@@ -23,7 +23,7 @@ Page objects also did not provide a pattern for handling service API calls.
 
 Pandy wanted to solve these problems by switching from page objects to the
 [Screenplay Pattern]({{ "/getting-started/screenplay/" | relative_url }}).
-Unfortunately, at that time, there were no major Screenplay inplementations in C#.
+Unfortunately, at that time, there were no major Screenplay implementations in C#.
 The most popular test framework using the Screenplay Pattern was
 [Serenity BDD](http://www.serenity-bdd.info/#/),
 which supports Java and JavaScript.

--- a/docs/pages/main-docs/tutorial/overview.md
+++ b/docs/pages/main-docs/tutorial/overview.md
@@ -15,7 +15,7 @@ This tutorial has two parts:
 
 1. [Part 1 - Setup]({{ "/tutorial/part-1-setup/" | relative_url }})
 2. [Part 2 - Web UI Testing]({{ "/tutorial/part-2-web-ui-testing/" | relative_url }})
-2. [Part 3 - REST API Testing]({{ "/tutorial/part-3-rest-api-testing/" | relative_url }})
+3. [Part 3 - REST API Testing]({{ "/tutorial/part-3-rest-api-testing/" | relative_url }})
 
 In the tutorial, you will build a small test project using [NUnit](https://nunit.org/).
 Inside, you will create a simple Web UI test case that performs a search using [DuckDuckGo](https://duckduckgo.com/).

--- a/docs/pages/user-guides/testing/specflow.md
+++ b/docs/pages/user-guides/testing/specflow.md
@@ -78,7 +78,7 @@ analogously to how an [NUnit `[SetUp]`]({{ "/user-guides/testing-with-nunit/#scr
 Before-scenario hooks must be located in binding classes and bear the `[BeforeScenario]` attribute.
 Binding classes may have multiple hooks, and hooks may optionally be assigned an order for execution.
 
-As a recommended practice, each Specflow test project should have a binding class for project-wide hooks.
+As a recommended practice, each SpecFlow test project should have a binding class for project-wide hooks.
 For Boa Constrictor, this binding class should have a before-scenario hook to
 construct an Actor for each test,
 add Abilities to the Actor,
@@ -123,7 +123,7 @@ namespace Boa.Constrictor.Example
 Whenever a Gherkin scenario runs, SpecFlow "glues" each Gherkin step to its associated step definition.
 Each step definition method has an annotation with the step type (`Given`, `When`, or `Then`)
 and a regular expression to match the step text.
-With Boa Constrictor, eacn step definition should be only a few lines of Screenplay interactions, like
+With Boa Constrictor, each step definition should be only a few lines of Screenplay interactions, like
 `Actor.AttemptsTo(...)`, `Actor.AsksFor(...)`, and `Actor.WaitsUntil(...)`.
 
 Below is a binding class named `DuckDuckGoSteps`


### PR DESCRIPTION
Fix typos and the formatting so that `SpecFlow` is properly capitalized in all references to the framework. Miscellaneous grammatical errors were also addressed to improve readability of documentation.