### PR TITLE
Improved checkboxes for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -71,5 +71,5 @@ body:
     options:
       - label: I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
         required: true
-      - label: I want to work on this issue myself.
+      - label: I want to work on this issue myself. (This is voluntary, not required.)
         required: false

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.yml
@@ -39,5 +39,5 @@ body:
     options:
       - label: I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
         required: true
-      - label: I want to work on this issue myself.
+      - label: I want to work on this issue myself. (This is voluntary, not required.)
         required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -31,5 +31,5 @@ body:
     options:
       - label: I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
         required: true
-      - label: I want to work on this issue myself.
+      - label: I want to work on this issue myself. (This is voluntary, not required.)
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `UploadFile` WebDriver Task
 - Added user guide: "Calling Tasks Safely"
-- Added GitHub templates for issues and pull requests
+- Added and refined GitHub templates for issues and pull requests
 
 ### Changed
 


### PR DESCRIPTION
## Description

> Please explain the changes included in this pull request.

The issue templates included a checkbox saying, "I want to work on this issue myself." This might make it seem like the requester is required to work on it themselves, which is not true. We want this checkbox to let us know if the requester wants to work on it or not. I added verbiage indicating it is voluntary.

## Testing

> Please explain the testing done for these changes.
> Include unit tests and feature tests.

We cannot test this until we merge it. :(

## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [changelog](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
