### PR TITLE
Fix capitalization on testing guide section titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added user guide: "Calling Tasks Safely"
 - Added and refined GitHub templates for issues and pull requests
 - Added user guide: "Writing Actor Extension Methods"
+- Reformatted section titles in testing guides
 
 ### Changed
 

--- a/docs/pages/user-guides/testing/nunit.md
+++ b/docs/pages/user-guides/testing/nunit.md
@@ -18,7 +18,7 @@ The example code matches the `ScreenplayWebUiTest` class in the `Boa.Constrictor
 (which is also part of the tutorial).
 
 
-## NUnit test projects
+## NUnit Test Projects
 
 Boa Constrictor can integrate with any NUnit test project.
 Full instructions for project setup are given by [Part 1 of the tutorial]({{ "/tutorial/part-1-setup/" | relative_url }}).
@@ -35,7 +35,7 @@ You may need to add other NuGet packages like
 [FluentAssertions](https://www.nuget.org/packages/FluentAssertions/) as well.
 
 
-## NUnit test classes
+## NUnit Test Classes
 
 NUnit test classes should have all the appropriate `using` statements for the namespaces they need.
 They should also have an instance variable for the Screenplay Actor object.
@@ -62,7 +62,7 @@ namespace Boa.Constrictor.Example
 ```
 
 
-## Screenplay SetUp methods
+## Screenplay SetUp Methods
 
 In NUnit test classes, methods with the `[SetUp]` attribute run before each test case to "set up" the test.
 Each test should have its own Actor with its own set of Abilities to preserve test case independence.
@@ -80,7 +80,7 @@ It constructs an Actor and gives it the Ability to browse the web with ChromeDri
 ```
 
 
-## Screenplay Test methods
+## Screenplay Test Methods
 
 In NUnit test classes, methods with the `[Test]` or `[TestCase]` attributes are individual test cases.
 With Boa Constrictor, most test cases should be a series of Screenplay interactions, like
@@ -100,7 +100,7 @@ Below is a test case method for the example `ScreenplayWebUiTest` class:
 ```
 
 
-## Screenplay TearDown methods
+## Screenplay TearDown Methods
 
 In NUnit test classes, methods with the `[TearDown]` attribute run after each test case to "tear down" (or "clean up") the test.
 Cleanup procedures are not required for all types of tests, but they are required for WebDriver-based tests.
@@ -117,7 +117,7 @@ It safely quits the browser for Web UI test cleanup:
 ```
 
 
-## A complete NUnit test class
+## A Complete NUnit Test Class
 
 The complete code for `ScreenplayWebUiTest` is below:
 

--- a/docs/pages/user-guides/testing/specflow.md
+++ b/docs/pages/user-guides/testing/specflow.md
@@ -22,7 +22,7 @@ as the test case from the [tutorial]({{ "/tutorial/overview/" | relative_url }})
 a Web UI test for DuckDuckGo searches.
 
 
-## SpecFlow test projects
+## SpecFlow Test Projects
 
 Boa Constrictor can integrate with any SpecFlow test project.
 If you are new to SpecFlow, read [SpecFlow's official documentation](https://docs.specflow.org/projects/specflow/en/latest/)
@@ -48,7 +48,7 @@ To [install SpecFlow+ Runner](https://docs.specflow.org/projects/specflow-runner
 you will need to register a (free) SpecFlow account.
 
 
-## Gherkin feature files
+## Gherkin Feature Files
 
 In SpecFlow, all tests are written in [Gherkin](https://docs.specflow.org/projects/specflow/en/latest/Gherkin/Gherkin-Reference.html)
 and saved in `.feature` files.
@@ -67,7 +67,7 @@ Feature: DuckDuckGo web search
 ```
 
 
-## Before-scenario hooks
+## Before-Scenario Hooks
 
 In SpecFlow, all automation code is located in "step definition" or "binding" classes.
 These classes require SpecFlow's `[Binding]` attribute, and they may also be child classes of the `Steps` class.
@@ -117,7 +117,7 @@ namespace Boa.Constrictor.Example
 ```
 
 
-## Step definition methods
+## Step Definition Methods
 
 "Step definitions" are special methods that execute Gherkin steps from feature files.
 Whenever a Gherkin scenario runs, SpecFlow "glues" each Gherkin step to its associated step definition.
@@ -177,7 +177,7 @@ namespace Boa.Constrictor.Example
 ```
 
 
-## After-scenario hooks
+## After-Scenario Hooks
 
 After-scenario hooks are analogous to 
 [NUnit `[TearDown]`]({{ "/user-guides/testing-with-nunit/#screenplay-teardown-methods" | relative_url }}) methods:

--- a/docs/pages/user-guides/testing/xunit-net.md
+++ b/docs/pages/user-guides/testing/xunit-net.md
@@ -19,7 +19,7 @@ as the test case from the [tutorial]({{ "/tutorial/overview/" | relative_url }})
 a Web UI test for DuckDuckGo searches.
 
 
-## xUnit.net test projects
+## xUnit.net Test Projects
 
 Boa Constrictor can integrate with any xUnit.net test project.
 If you are new to xUnit.net, read [xUnit.net's official documentation](https://xunit.net/#documentation)
@@ -37,7 +37,7 @@ You may need to add other NuGet packages like
 [FluentAssertions](https://www.nuget.org/packages/FluentAssertions/) as well.
 
 
-## xUnit.net test classes
+## xUnit.net Test Classes
 
 xUnit.net test classes should have all the appropriate `using` statements for the namespaces they need.
 They should also have an instance variable for the Screenplay Actor object.
@@ -62,7 +62,7 @@ namespace Boa.Constrictor.Example
 ```
 
 
-## Screenplay setup
+## Screenplay Setup
 
 xUnit.net test classes do not have "set up" methods like
 [NUnit's `[SetUp]` methods]({{ "/user-guides/testing-with-nunit/#screenplay-setup-methods" | relative_url }}).
@@ -81,7 +81,7 @@ constructs an Actor and gives it the Ability to browse the web with ChromeDriver
 ```
 
 
-## Screenplay test case
+## Screenplay Test Case
 
 In xUnit.net test classes, methods with the `[Fact]` or `[Theory]` attributes are individual test cases.
 With Boa Constrictor, most test cases should be a series of Screenplay interactions, like
@@ -110,7 +110,7 @@ You can use [FluentAssertions](https://www.nuget.org/packages/FluentAssertions/)
 ```
 
 
-## Screenplay cleanup
+## Screenplay Cleanup
 
 Cleanup procedures are not required for all types of tests, but they are required for WebDriver-based tests.
 xUnit.net test classes must implement the `System.IDisposable` interface to handle test case cleanup:
@@ -130,7 +130,7 @@ The code below safely quits the browser for Web UI test cleanup:
 ```
 
 
-## A complete xUnit.net test class
+## A Complete xUnit.net Test Class
 
 The complete code for `DuckDuckGoTest` is below:
 


### PR DESCRIPTION
## Description

> Please explain the changes included in this pull request.

Fixed capitalization on testing guide section titles to conform to MLA style rules.

## Testing

> Please explain the testing done for these changes.
> Include unit tests and feature tests.

No code changes made. Served site locally with Jekyll.

## Checklist

- [ ✔️ ] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [ ✔️ ] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [ ✔️ ] I successfully built the .NET solution with no errors or new warnings.
- [ ✔️ ] I successfully ran both the unit tests and the example tests.
- [ ✔️ ] I updated the [changelog](CHANGELOG.md) with concise descriptions of these changes.
- [ ✔️ ] I added documentation for these changes (if appropriate).
