### PR TITLE
bump Selenium version to 4.1 and remove deps in Examples project

### DIFF
--- a/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
+++ b/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
@@ -12,8 +12,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
-    <PackageReference Include="Selenium.Support" Version="4.0.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
-    <PackageReference Include="Selenium.Support" Version="4.0.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.0.0" />
+    <PackageReference Include="Selenium.Support" Version="4.1.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added unit tests for Question that derive from `AbstractWebPropertyQuestion`
 - Added [Discord server](https://discord.gg/pP3dXzYQ82) invitation links to README and docs
+- Bumped Selenium to 4.1.
 
 
 ## [2.0.0] - 2021-11-02


### PR DESCRIPTION
## Description

Bumping Selenium from 4.0 to 4.1 so that people can benefit from the packages.
I also removed the dependency on Selenium in the Examples project - considering the tool itself provides that dependency, that leaves the solution with only 1 source of truth for package versions and easier to maintain by just updating the main package.

## Testing

Testing was only limited to existing tests as I don't see any new tests being needed.

## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [changelog](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
