### PR TITLE
Removed Boa.Constrictor step from nuget-push.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,7 @@
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
-name: "CodeQL"
+name: Run CodeQL static analysis
 
 on:
   push:

--- a/.github/workflows/nuget-push-classic.yml
+++ b/.github/workflows/nuget-push-classic.yml
@@ -1,7 +1,7 @@
 # Builds and publishes the classic Boa.Constrictor package to NuGet.org whenever versions change.
 # The NuGet key is currently Andy Knight's NuGet account.
 
-name: Publish the classic Boa Constrictor Package
+name: Publish the classic NuGet package
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -1,7 +1,7 @@
 # Builds and publishes the Boa Constrictor packages to NuGet.org whenever versions change.
 # The NuGet key is currently Andy Knight's NuGet account.
 
-name: Publish Boa Constrictor NuGet Packages
+name: Publish the main NuGet packages
 
 on:
   push:

--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -117,37 +117,3 @@ jobs:
           # (Furthermore, including a NuGet package README breaks in .NET 5 when a symbols package is generated)
           # (This GitHub Action will yield a failure when publishing a symbols package, too, even though the publishing succeeds)
           INCLUDE_SYMBOLS: false
-
-      - name: Publish Boa.Constrictor package
-        if: always()
-        uses: rohith/publish-nuget@v2
-        with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: Boa.Constrictor/Boa.Constrictor.csproj
-          
-          # NuGet package id, used for version detection & defaults to project name
-          PACKAGE_NAME: Boa.Constrictor
-          
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          VERSION_FILE_PATH: Boa.Constrictor/Boa.Constrictor.csproj
-
-          # Regex pattern to extract version info in a capturing group
-          VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          
-          # Flag to toggle git tagging, enabled by default
-          TAG_COMMIT: true
-
-          # Format of the git tag, [*] gets replaced with actual version
-          TAG_FORMAT: v*
-
-          # API key to authenticate with NuGet server
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # (The symbols package should no longer be needed because the project is configured with DebugType = "embedded")
-          # (Furthermore, including a NuGet package README breaks in .NET 5 when a symbols package is generated)
-          # (This GitHub Action will yield a failure when publishing a symbols package, too, even though the publishing succeeds)
-          INCLUDE_SYMBOLS: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,7 @@
 # Runs the NUnit unit tests located in the Boa.Constrictor.UnitTests project.
 # Warning: Does not run the example tests in the Boa.Constrictor.Example project.
 
-name: Boa Constrictor Unit Tests
+name: Run all unit tests
 
 on:
   pull_request:


### PR DESCRIPTION
This got moved to the "classic" action for manual triggers. I also renamed the actions.