### PR TITLE
Rewrote NuGet push GitHub Action to use dotnet commands directly

### DIFF
--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -1,6 +1,6 @@
 # Builds and publishes the Boa Constrictor packages to NuGet.org whenever versions change.
 # The NuGet key is currently Andy Knight's NuGet account.
-# There are 10-minute sleeps because NuGet needs time to index new packages before they are made available.
+# There are 8-minute sleeps because NuGet needs time to index new packages before they are made available.
 
 name: Publish NuGet packages
 
@@ -36,8 +36,8 @@ jobs:
 
       # Selenium and RestSharp
 
-      - name: Wait 10 minutes for NuGet indexing
-        run: Start-Sleep -s 600
+      - name: Wait 8 minutes for NuGet indexing
+        run: Start-Sleep -s 480
         shell: powershell
 
       - name: Pack Boa.Constrictor.Selenium project
@@ -55,8 +55,8 @@ jobs:
 
       # Classic
 
-      - name: Wait 10 minutes for NuGet indexing
-        run: Start-Sleep -s 600
+      - name: Wait 8 minutes for NuGet indexing
+        run: Start-Sleep -s 480
         shell: powershell
 
       - name: Pack Boa.Constrictor project

--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -1,7 +1,6 @@
 # Builds and publishes the Boa Constrictor packages to NuGet.org whenever versions change.
 # The NuGet key is currently Andy Knight's NuGet account.
-# Warning: rohith/publish-nuget@v2 logs a failure even when packages are published successfully.
-# The `if: always()` condition guarantees that steps will run as a workaround.
+# There are 10-minute sleeps because NuGet needs time to index new packages before they are made available.
 
 name: Publish NuGet packages
 
@@ -15,150 +14,53 @@ jobs:
     runs-on: windows-latest
     steps:
 
+      # Prepare the environment
+
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Publish Boa.Constrictor.Screenplay package
-        if: always()
-        uses: rohith/publish-nuget@v2
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v3
         with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj
-          
-          # NuGet package id, used for version detection & defaults to project name
-          PACKAGE_NAME: Boa.Constrictor.Screenplay
-          
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          VERSION_FILE_PATH: Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj
+          dotnet-version: '7.0.x'
 
-          # Regex pattern to extract version info in a capturing group
-          VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          
-          # Flag to toggle git tagging, enabled by default
-          TAG_COMMIT: true
 
-          # Format of the git tag, [*] gets replaced with actual version
-          TAG_FORMAT: v*
+      # Screenplay
 
-          # API key to authenticate with NuGet server
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      - name: Pack Boa.Constrictor.Screenplay project
+        run: dotnet pack --configuration Release Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj --output Screenplay
 
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          NUGET_SOURCE: https://api.nuget.org
+      - name: Push Boa.Constrictor.Screenplay package
+        run: dotnet nuget push Screenplay/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # (The symbols package should no longer be needed because the project is configured with DebugType = "embedded")
-          # (Furthermore, including a NuGet package README breaks in .NET 5 when a symbols package is generated)
-          # (This GitHub Action will yield a failure when publishing a symbols package, too, even though the publishing succeeds)
-          INCLUDE_SYMBOLS: false
+
+      # Selenium and RestSharp
 
       - name: Wait 10 minutes for NuGet indexing
-        if: always()
         run: Start-Sleep -s 600
         shell: powershell
 
-      - name: Publish Boa.Constrictor.Selenium package
-        if: always()
-        uses: rohith/publish-nuget@v2
-        with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
-          
-          # NuGet package id, used for version detection & defaults to project name
-          PACKAGE_NAME: Boa.Constrictor.Selenium
-          
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          VERSION_FILE_PATH: Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
+      - name: Pack Boa.Constrictor.Selenium project
+        run: dotnet pack --configuration Release Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj --output Selenium
 
-          # Regex pattern to extract version info in a capturing group
-          VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          
-          # Flag to toggle git tagging, enabled by default
-          TAG_COMMIT: true
+      - name: Push Boa.Constrictor.Selenium package
+        run: dotnet nuget push Selenium/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
-          # Format of the git tag, [*] gets replaced with actual version
-          TAG_FORMAT: v*
+      - name: Pack Boa.Constrictor.RestSharp project
+        run: dotnet pack --configuration Release Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj --output RestSharp
 
-          # API key to authenticate with NuGet server
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      - name: Push Boa.Constrictor.RestSharp package
+        run: dotnet nuget push RestSharp/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          NUGET_SOURCE: https://api.nuget.org
 
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # (The symbols package should no longer be needed because the project is configured with DebugType = "embedded")
-          # (Furthermore, including a NuGet package README breaks in .NET 5 when a symbols package is generated)
-          # (This GitHub Action will yield a failure when publishing a symbols package, too, even though the publishing succeeds)
-          INCLUDE_SYMBOLS: false
-
-      - name: Publish Boa.Constrictor.RestSharp package
-        if: always()
-        uses: rohith/publish-nuget@v2
-        with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
-          
-          # NuGet package id, used for version detection & defaults to project name
-          PACKAGE_NAME: Boa.Constrictor.RestSharp
-          
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          VERSION_FILE_PATH: Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
-
-          # Regex pattern to extract version info in a capturing group
-          VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          
-          # Flag to toggle git tagging, enabled by default
-          TAG_COMMIT: true
-
-          # Format of the git tag, [*] gets replaced with actual version
-          TAG_FORMAT: v*
-
-          # API key to authenticate with NuGet server
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # (The symbols package should no longer be needed because the project is configured with DebugType = "embedded")
-          # (Furthermore, including a NuGet package README breaks in .NET 5 when a symbols package is generated)
-          # (This GitHub Action will yield a failure when publishing a symbols package, too, even though the publishing succeeds)
-          INCLUDE_SYMBOLS: false
+      # Classic
 
       - name: Wait 10 minutes for NuGet indexing
-        if: always()
         run: Start-Sleep -s 600
         shell: powershell
 
-      - name: Publish Boa.Constrictor package
-        uses: rohith/publish-nuget@v2
-        with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: Boa.Constrictor/Boa.Constrictor.csproj
-          
-          # NuGet package id, used for version detection & defaults to project name
-          PACKAGE_NAME: Boa.Constrictor
-          
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          VERSION_FILE_PATH: Boa.Constrictor/Boa.Constrictor.csproj
+      - name: Pack Boa.Constrictor project
+        run: dotnet pack --configuration Release Boa.Constrictor/Boa.Constrictor.csproj --output Classic
 
-          # Regex pattern to extract version info in a capturing group
-          VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          
-          # Flag to toggle git tagging, enabled by default
-          TAG_COMMIT: true
-
-          # Format of the git tag, [*] gets replaced with actual version
-          TAG_FORMAT: v*
-
-          # API key to authenticate with NuGet server
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # (The symbols package should no longer be needed because the project is configured with DebugType = "embedded")
-          # (Furthermore, including a NuGet package README breaks in .NET 5 when a symbols package is generated)
-          # (This GitHub Action will yield a failure when publishing a symbols package, too, even though the publishing succeeds)
-          INCLUDE_SYMBOLS: false
+      - name: Push Boa.Constrictor package
+        run: dotnet nuget push Classic/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
+++ b/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;net7.0;netstandard2.0</TargetFrameworks>
-    <Version>3.0.2-alpha1</Version>
+    <Version>3.0.2-alpha2</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>Q2</Company>
     <Title>Boa Constrictor</Title>
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="Boa.Constrictor.Screenplay" Version="3.0.2-alpha1" />
+    <PackageReference Include="Boa.Constrictor.Screenplay" Version="3.0.2-alpha2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj
+++ b/Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;net7.0;netstandard2.0</TargetFrameworks>
-    <Version>3.0.2-alpha1</Version>
+    <Version>3.0.2-alpha2</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>Q2</Company>
     <Title>Boa Constrictor</Title>

--- a/Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
+++ b/Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;net7.0;netstandard2.0</TargetFrameworks>
-    <Version>3.0.2-alpha1</Version>
+    <Version>3.0.2-alpha2</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>Q2</Company>
     <Title>Boa Constrictor</Title>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="Boa.Constrictor.Screenplay" Version="3.0.2-alpha1" />
+    <PackageReference Include="Boa.Constrictor.Screenplay" Version="3.0.2-alpha2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Boa.Constrictor/Boa.Constrictor.csproj
+++ b/Boa.Constrictor/Boa.Constrictor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;net7.0;netstandard2.0</TargetFrameworks>
-    <Version>3.0.2-alpha1</Version>
+    <Version>3.0.2-alpha2</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>Q2</Company>
     <Title>Boa Constrictor</Title>
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="Boa.Constrictor.RestSharp" Version="3.0.2-alpha1" />
-    <PackageReference Include="Boa.Constrictor.Screenplay" Version="3.0.2-alpha1" />
-    <PackageReference Include="Boa.Constrictor.Selenium" Version="3.0.2-alpha1" />
+    <PackageReference Include="Boa.Constrictor.RestSharp" Version="3.0.2-alpha2" />
+    <PackageReference Include="Boa.Constrictor.Screenplay" Version="3.0.2-alpha2" />
+    <PackageReference Include="Boa.Constrictor.Selenium" Version="3.0.2-alpha2" />
   </ItemGroup>
 
 </Project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (none)
 
 
+## [3.0.2-alpha2] - 2022-12-04
+
+### Changed
+
+- Rewrote `nuget-push.yml` to use `dotnet` commands directly instead of `rohith/publish-nuget`
+
+
 ## [3.0.2-alpha1] - 2022-12-04
 
 ### Fixed


### PR DESCRIPTION
## Description

The GitHub Action to pack and push NuGet packages used an old, abandoned action. I rewrote our action to use `dotnet` commands directly.



## Testing

Unfortunately, we can't test this locally. We might need to try making a few pull requests to get it right. I bumped the version to `3.0.2-alpha2` to trigger the action.



## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [changelog](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
