### PR TITLE
Will dotnet build before dotnet pack fix the failure?

### DIFF
--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -27,8 +27,11 @@ jobs:
 
       # Screenplay
 
+      - name: Build Boa.Constrictor.Screenplay project
+        run: dotnet build --configuration Release Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj
+
       - name: Pack Boa.Constrictor.Screenplay project
-        run: dotnet pack --configuration Release Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj --output Screenplay
+        run: dotnet pack --configuration Release Boa.Constrictor.Screenplay/Boa.Constrictor.Screenplay.csproj --no-build --output Screenplay
 
       - name: Push Boa.Constrictor.Screenplay package
         run: dotnet nuget push Screenplay/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
@@ -40,14 +43,20 @@ jobs:
         run: Start-Sleep -s 480
         shell: powershell
 
+      - name: Build Boa.Constrictor.Selenium project
+        run: dotnet build --configuration Release Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
+
       - name: Pack Boa.Constrictor.Selenium project
-        run: dotnet pack --configuration Release Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj --output Selenium
+        run: dotnet pack --configuration Release Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj --no-build --output Selenium
 
       - name: Push Boa.Constrictor.Selenium package
         run: dotnet nuget push Selenium/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
+      - name: Build Boa.Constrictor.RestSharp project
+        run: dotnet build --configuration Release Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
+
       - name: Pack Boa.Constrictor.RestSharp project
-        run: dotnet pack --configuration Release Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj --output RestSharp
+        run: dotnet pack --configuration Release Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj --no-build --output RestSharp
 
       - name: Push Boa.Constrictor.RestSharp package
         run: dotnet nuget push RestSharp/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
@@ -59,8 +68,11 @@ jobs:
         run: Start-Sleep -s 480
         shell: powershell
 
+      - name: Build Boa.Constrictor project
+        run: dotnet build --configuration Release Boa.Constrictor/Boa.Constrictor.csproj
+
       - name: Pack Boa.Constrictor project
-        run: dotnet pack --configuration Release Boa.Constrictor/Boa.Constrictor.csproj --output Classic
+        run: dotnet pack --configuration Release Boa.Constrictor/Boa.Constrictor.csproj --no-build --output Classic
 
       - name: Push Boa.Constrictor package
         run: dotnet nuget push Classic/**/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Updated doc site dependencies to resolve security warnings
+(none)
 
 
 ## [3.0.2-alpha2] - 2022-12-04
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rewrote `nuget-push.yml` to use `dotnet` commands directly instead of `rohith/publish-nuget`
+- Updated doc site dependencies to resolve security warnings
 
 
 ## [3.0.2-alpha1] - 2022-12-04


### PR DESCRIPTION
## Description

The `nuget-push.yml` changes failed. Now, we need to iterate through trial-and-error changes. Get ready for a potential flurry of pull requests.

The docs say `dotnet pack` will build by default, but that didn't appear to be the case. The old action we used explicitly calls `build` before `pack`. Let's try that.



## Testing

This is the test.



## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [changelog](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
