### PR TITLE
Added headless Chrome to example tests to run them with CI

### DIFF
--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -1,0 +1,31 @@
+# Runs the example tests in the Boa.Constrictor.Example project.
+
+name: Run all example tests
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: windows-latest
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Build the solution
+        run: dotnet build
+
+      - name: Run example tests
+        run: dotnet test Boa.Constrictor.Example --logger "trx;LogFileName=ExampleResults.trx"
+
+      - name: Archive example test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: Example test results
+          path: Boa.Constrictor.Example/TestResults/ExampleResults.trx
+          retention-days: 30
+          

--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -7,6 +7,7 @@ name: Publish NuGet packages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
       
 jobs:
   publish:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,7 @@ name: Run all unit tests
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -21,15 +22,15 @@ jobs:
 
       - name: Run Screenplay unit tests
         if: always()
-        run: dotnet test Boa.Constrictor.Screenplay.UnitTests/Boa.Constrictor.Screenplay.UnitTests.csproj --logger "trx;LogFileName=ScreenplayResults.trx"
+        run: dotnet test Boa.Constrictor.Screenplay.UnitTests --logger "trx;LogFileName=ScreenplayResults.trx"
 
       - name: Run Selenium unit tests
         if: always()
-        run: dotnet test Boa.Constrictor.Selenium.UnitTests/Boa.Constrictor.Selenium.UnitTests.csproj --logger "trx;LogFileName=SeleniumResults.trx"
+        run: dotnet test Boa.Constrictor.Selenium.UnitTests --logger "trx;LogFileName=SeleniumResults.trx"
 
       - name: Run RestSharp unit tests
         if: always()
-        run: dotnet test Boa.Constrictor.RestSharp.UnitTests/Boa.Constrictor.RestSharp.UnitTests.csproj --logger "trx;LogFileName=RestSharpResults.trx"
+        run: dotnet test Boa.Constrictor.RestSharp.UnitTests --logger "trx;LogFileName=RestSharpResults.trx"
 
       - name: Archive Screenplay unit test results
         if: always()

--- a/Boa.Constrictor.Example/CHANGELOG.md
+++ b/Boa.Constrictor.Example/CHANGELOG.md
@@ -17,12 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versioning is performed purely for tracking changes.
 
 
-## [Unreleased]
-
-(none)
-
-
 ## [3.0.3-alpha1] - 2022-12-08
+
+### Added
+
+- Enabled headless Chrome in the example Web UI test
+- Created a GitHub Action to run the example tests for pull requests into `main`
 
 ### Changed
 

--- a/Boa.Constrictor.Example/Tests/ScreenplayWebUiTest.cs
+++ b/Boa.Constrictor.Example/Tests/ScreenplayWebUiTest.cs
@@ -13,13 +13,12 @@ namespace Boa.Constrictor.Example
         [SetUp]
         public void InitializeScreenplay()
         {
-            // Adding headless mode for CI
-            // Comment this code out to go "headed" - to see the browser
             ChromeOptions options = new ChromeOptions();
-            options.AddArgument("headless");
+            options.AddArgument("headless");   // Remove this line to "see" the browser run
+            ChromeDriver driver = new ChromeDriver(options);
 
             Actor = new Actor(name: "Andy", logger: new ConsoleLogger());
-            Actor.Can(BrowseTheWeb.With(new ChromeDriver(options)));
+            Actor.Can(BrowseTheWeb.With(driver));
         }
 
         [TearDown]

--- a/Boa.Constrictor.Example/Tests/ScreenplayWebUiTest.cs
+++ b/Boa.Constrictor.Example/Tests/ScreenplayWebUiTest.cs
@@ -13,8 +13,13 @@ namespace Boa.Constrictor.Example
         [SetUp]
         public void InitializeScreenplay()
         {
+            // Adding headless mode for CI
+            // Comment this code out to go "headed" - to see the browser
+            ChromeOptions options = new ChromeOptions();
+            options.AddArgument("headless");
+
             Actor = new Actor(name: "Andy", logger: new ConsoleLogger());
-            Actor.Can(BrowseTheWeb.With(new ChromeDriver()));
+            Actor.Can(BrowseTheWeb.With(new ChromeDriver(options)));
         }
 
         [TearDown]

--- a/docs/pages/main-docs/tutorial/part-2-web-ui-testing.md
+++ b/docs/pages/main-docs/tutorial/part-2-web-ui-testing.md
@@ -146,6 +146,20 @@ Let's unpack what this line does:
 You could use a different browser type here, and you could also specify WebDriver options.
 {: .notice--info}
 
+<div class="notice--info" markdown="1">
+
+**Headless Mode:**
+You could use headless Chrome by setting options like this:
+{: style="font-size:1em" }
+
+```csharp
+ChromeOptions options = new ChromeOptions();
+options.AddArgument("headless");
+ChromeDriver driver = new ChromeDriver(options);
+```
+{: style="font-size:1em" }
+</div>
+
 Abilities must implement the `IAbility` interface:
 
 ```csharp
@@ -701,8 +715,12 @@ namespace Boa.Constrictor.Example
         [SetUp]
         public void InitializeScreenplay()
         {
+            ChromeOptions options = new ChromeOptions();
+            options.AddArgument("headless");   // Remove this line to "see" the browser run
+            ChromeDriver driver = new ChromeDriver(options);
+
             Actor = new Actor(name: "Andy", logger: new ConsoleLogger());
-            Actor.Can(BrowseTheWeb.With(new ChromeDriver()));
+            Actor.Can(BrowseTheWeb.With(driver));
         }
 
         [TearDown]


### PR DESCRIPTION
## Description

We should run the example along with the unit tests whenever someone opens a pull request. However, we need to make the example code run Chrome in headless mode, or else WebDriver will likely crash.

Therefore:
- I updated the example code.
- I updated the tutorial instructions.
- I added a GitHub Action to run the example tests.


## Testing

I tested locally, but the real test will be in GitHub Actions.



## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
