### PR TITLE
Removed push trigger for codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@
 name: Run CodeQL static analysis
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/Boa.Constrictor/CHANGELOG.md
+++ b/Boa.Constrictor/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+### Removed
+
+- Removed `push` trigger for `codeql-analysis.yml` GitHub Action
 
 
 ## [3.0.3-alpha1] - 2022-12-08


### PR DESCRIPTION
## Description

Since every push/merge into the `main` branch requires a pull request with a code review, there's no need to trigger the CodeQL GitHub Action on a push to `main` as well as a pull request into `main`. I removed that workflow trigger.



## Testing

We can't test the workflow until we perform the merge.



## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
