### PR TITLE
Changed AnswerCache to use Hashtable

### DIFF
--- a/Boa.Constrictor.Screenplay/CHANGELOG.md
+++ b/Boa.Constrictor.Screenplay/CHANGELOG.md
@@ -17,7 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+### Added
+
+- Wrote new `AnswerCacheTest` unit tests for different types and different question objects
+
+### Changed
+
+- Converted `AnswerCache` to use a `Hashtable` instead of a pointlessly generic `IDictionary`
 
 
 ## [3.0.3-alpha1] - 2022-12-08

--- a/Boa.Constrictor.Screenplay/Screenplay/Caching/AnswerCache.cs
+++ b/Boa.Constrictor.Screenplay/Screenplay/Caching/AnswerCache.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
 
 namespace Boa.Constrictor.Screenplay
 {
@@ -21,7 +21,7 @@ namespace Boa.Constrictor.Screenplay
         /// The answer cache.
         /// Maps Question objects to answer objects.
         /// </summary>
-        protected IDictionary<IInteraction, object> Cache { get; set; }
+        protected Hashtable Cache { get; set; }
 
         #endregion
 
@@ -33,7 +33,7 @@ namespace Boa.Constrictor.Screenplay
         /// </summary>
         public AnswerCache()
         {
-            Cache = new Dictionary<IInteraction, object>();
+            Cache = new Hashtable();
         }
 
         #endregion


### PR DESCRIPTION
## Description

The storage object inside `AnswerCache` used `IDictionary<IInteraction, object>` when it could more simply use `Hashtable`. I made this change, updated unit tests, and ran all the unit tests to make sure it works.



## Testing

I built and tested locally.



## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
