### PR TITLE
Update RestSharp to 108.3

### DIFF
--- a/Boa.Constrictor.Example/CHANGELOG.md
+++ b/Boa.Constrictor.Example/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 *Note:* This project does not have a NuGet package.
 Versioning is performed purely for tracking changes.
 
+## [Unreleased]
+
+### Changed
+- DogRequests now uses `RestRequest` to support RestSharp updates
 
 ## [3.0.3] - 2022-12-13
 

--- a/Boa.Constrictor.Example/Requests/DogRequests.cs
+++ b/Boa.Constrictor.Example/Requests/DogRequests.cs
@@ -4,7 +4,7 @@ namespace Boa.Constrictor.Example
 {
     public static class DogRequests
     {
-        public static IRestRequest GetRandomDog() =>
-            new RestRequest("api/breeds/image/random", Method.GET);
+        public static RestRequest GetRandomDog() =>
+            new RestRequest("api/breeds/image/random", Method.Get);
     }
 }

--- a/Boa.Constrictor.RestSharp.UnitTests/Boa.Constrictor.RestSharp.UnitTests.csproj
+++ b/Boa.Constrictor.RestSharp.UnitTests/Boa.Constrictor.RestSharp.UnitTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Boa.Constrictor.RestSharp.UnitTests/Serialization/DurationDataTest.cs
+++ b/Boa.Constrictor.RestSharp.UnitTests/Serialization/DurationDataTest.cs
@@ -1,7 +1,8 @@
-﻿using Boa.Constrictor.RestSharp;
+﻿using System;
+
 using FluentAssertions;
+
 using NUnit.Framework;
-using System;
 
 namespace Boa.Constrictor.RestSharp.UnitTests
 {

--- a/Boa.Constrictor.RestSharp.UnitTests/Serialization/ParameterDataTest.cs
+++ b/Boa.Constrictor.RestSharp.UnitTests/Serialization/ParameterDataTest.cs
@@ -1,12 +1,14 @@
-﻿using Boa.Constrictor.RestSharp;
+﻿using System.Collections.Generic;
+
 using FluentAssertions;
+
 using NUnit.Framework;
+
 using RestSharp;
-using System.Collections.Generic;
 
 namespace Boa.Constrictor.RestSharp.UnitTests
 {
-    #pragma warning disable 0618
+#pragma warning disable 0618
 
     [TestFixture]
     public class ParameterDataTest
@@ -16,8 +18,8 @@ namespace Boa.Constrictor.RestSharp.UnitTests
         {
             var parameters = new List<Parameter>()
             {
-                new Parameter("p1", "hello", ParameterType.HttpHeader),
-                new Parameter("p2", "goodbye", ParameterType.Cookie),
+                new HeaderParameter("p1", "hello"),
+                new GetOrPostParameter("p2", "goodbye"),
             };
 
             var list = ParameterData.GetParameterDataList(parameters);
@@ -27,7 +29,7 @@ namespace Boa.Constrictor.RestSharp.UnitTests
             list[0].Type.Should().Be(ParameterType.HttpHeader.ToString());
             list[1].Name.Should().Be("p2");
             list[1].Value.Should().Be("goodbye");
-            list[1].Type.Should().Be(ParameterType.Cookie.ToString());
+            list[1].Type.Should().Be(ParameterType.GetOrPost.ToString());
         }
 
         [Test]
@@ -37,6 +39,5 @@ namespace Boa.Constrictor.RestSharp.UnitTests
         }
     }
 
-    #pragma warning restore 0618
-
+#pragma warning restore 0618
 }

--- a/Boa.Constrictor.RestSharp/Abilities/AbstractRestSharpAbility.cs
+++ b/Boa.Constrictor.RestSharp/Abilities/AbstractRestSharpAbility.cs
@@ -28,14 +28,14 @@ namespace Boa.Constrictor.RestSharp
         /// (Use static methods in a subclass for public construction.)
         /// </summary>
         /// <param name="client">The RestSharp client.</param>
-        protected AbstractRestSharpAbility(IRestClient client)
+        protected AbstractRestSharpAbility(RestClient client)
         {
             Client = client;
             RequestDumper = null;
             DownloadDumper = null;
 
-            if (Client.CookieContainer == null)
-                Client.CookieContainer = new CookieContainer();
+            if (Client.Options.CookieContainer == null)
+                Client.Options.CookieContainer = new CookieContainer();
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Boa.Constrictor.RestSharp
         /// <summary>
         /// The RestSharp client.
         /// </summary>
-        public IRestClient Client { get; protected set; }
+        public RestClient Client { get; protected set; }
 
         /// <summary>
         /// The dumper for downloaded files.
@@ -70,13 +70,13 @@ namespace Boa.Constrictor.RestSharp
         /// The last request object dumped.
         /// Warning: it might be null.
         /// </summary>
-        public IRestRequest LastRequest => RequestDumper.LastRequest;
+        public RestRequest LastRequest => RequestDumper.LastRequest;
 
         /// <summary>
         /// The last response object dumped.
         /// Warning: it might be null.
         /// </summary>
-        public IRestResponse LastResponse => RequestDumper.LastResponse;
+        public RestResponse LastResponse => RequestDumper.LastResponse;
 
         #endregion
 
@@ -106,13 +106,13 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="name">The cookie name.</param>
         /// <returns></returns>
-        public Cookie GetCookie(string name) => Client.CookieContainer.GetCookies(Client.BaseUrl)[name];
+        public Cookie GetCookie(string name) => Client.CookieContainer.GetCookies(Client.Options.BaseUrl)[name];
 
         /// <summary>
         /// Returns a description of this Ability.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"call REST API at: {Client.BaseUrl}";
+        public override string ToString() => $"call REST API at: {Client.Options.BaseUrl}";
 
         #endregion
     }

--- a/Boa.Constrictor.RestSharp/Abilities/CallRestApi.cs
+++ b/Boa.Constrictor.RestSharp/Abilities/CallRestApi.cs
@@ -28,7 +28,7 @@ namespace Boa.Constrictor.RestSharp
         /// (Use static builder methods for public construction.)
         /// </summary>
         /// <param name="client">The RestSharp client.</param>
-        protected CallRestApi(IRestClient client) : base(client) { }
+        protected CallRestApi(RestClient client) : base(client) { }
 
         /// <summary>
         /// Protected constructor.
@@ -53,7 +53,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="client">The RestSharp client.</param>
         /// <returns></returns>
-        public static CallRestApi Using(IRestClient client) => new CallRestApi(client);
+        public static CallRestApi Using(RestClient client) => new CallRestApi(client);
 
         /// <summary>
         /// Sets the Ability to dump requests/responses to the given path.

--- a/Boa.Constrictor.RestSharp/Abilities/IRestSharpAbility.cs
+++ b/Boa.Constrictor.RestSharp/Abilities/IRestSharpAbility.cs
@@ -21,7 +21,7 @@ namespace Boa.Constrictor.RestSharp
         /// <summary>
         /// The RestSharp client.
         /// </summary>
-        IRestClient Client { get; }
+        RestClient Client { get; }
 
         /// <summary>
         /// The dumper for downloaded files.
@@ -37,13 +37,13 @@ namespace Boa.Constrictor.RestSharp
         /// The last request object dumped.
         /// Warning: it might be null.
         /// </summary>
-        IRestRequest LastRequest { get; }
+        RestRequest LastRequest { get; }
 
         /// <summary>
         /// The last response object dumped.
         /// Warning: it might be null.
         /// </summary>
-        IRestResponse LastResponse { get; }
+        RestResponse LastResponse { get; }
 
         #endregion
 

--- a/Boa.Constrictor.RestSharp/Abilities/RequestDumper.cs
+++ b/Boa.Constrictor.RestSharp/Abilities/RequestDumper.cs
@@ -15,13 +15,13 @@ namespace Boa.Constrictor.RestSharp
         /// The last request object dumped.
         /// Warning: it might be null.
         /// </summary>
-        public IRestRequest LastRequest { get; private set; } = null;
+        public RestRequest LastRequest { get; private set; } = null;
 
         /// <summary>
         /// The last response object dumped.
         /// Warning: it might be null.
         /// </summary>
-        public IRestResponse LastResponse { get; private set; } = null;
+        public RestResponse LastResponse { get; private set; } = null;
 
         #endregion
 
@@ -51,9 +51,9 @@ namespace Boa.Constrictor.RestSharp
         /// <param name="end">Request's end time.</param>
         /// <returns></returns>
         public string Dump(
-            IRestClient client,
-            IRestRequest request = null,
-            IRestResponse response = null,
+            RestClient client,
+            RestRequest request = null,
+            RestResponse response = null,
             DateTime? start = null,
             DateTime? end = null)
         {

--- a/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
+++ b/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="RestSharp" Version="108.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">

--- a/Boa.Constrictor.RestSharp/CHANGELOG.md
+++ b/Boa.Constrictor.RestSharp/CHANGELOG.md
@@ -17,7 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+### Changed
+- Updated RestSharp to 108.3
+	- All instances of the following interfaces have been replaced with concrete classes
+		- `IRestClient` -> `RestClient`
+		- `IRestRequest` -> `RestRequest`
+		- `IRestResponse` -> `RestResponse`
+	- See the [Migration Guide](https://restsharp.dev/v107/#brief-migration-guide) for more details
+- Changed `RequestDumper` serialization to support RestSharp 108.3
+- Fixed unit tests. Replaced the use of Moq with MockHttp where necessary as recommended [here](https://restsharp.dev/v107/#mocking)
 
 
 ## [3.0.3] - 2022-12-13

--- a/Boa.Constrictor.RestSharp/Exceptions/RestApiDownloadException.cs
+++ b/Boa.Constrictor.RestSharp/Exceptions/RestApiDownloadException.cs
@@ -14,7 +14,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="request">The request object.</param>
         /// <param name="response">The response object.</param>
-        public RestApiDownloadException(IRestRequest request, IRestResponse response) 
+        public RestApiDownloadException(RestRequest request, RestResponse response) 
             : base("REST API file download failed")
         {
             Request = request;
@@ -28,12 +28,12 @@ namespace Boa.Constrictor.RestSharp
         /// <summary>
         /// The request object.
         /// </summary>
-        public IRestRequest Request { get; }
+        public RestRequest Request { get; }
 
         /// <summary>
         /// The response object.
         /// </summary>
-        public IRestResponse Response { get;  }
+        public RestResponse Response { get;  }
 
         #endregion
     }

--- a/Boa.Constrictor.RestSharp/Interactions/AbstractRestQuestion.cs
+++ b/Boa.Constrictor.RestSharp/Interactions/AbstractRestQuestion.cs
@@ -18,7 +18,7 @@ namespace Boa.Constrictor.RestSharp
         /// <summary>
         /// The REST request to call.
         /// </summary>
-        public IRestRequest Request { get; private set; }
+        public RestRequest Request { get; private set; }
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Boa.Constrictor.RestSharp
         /// Protected constructor.
         /// </summary>
         /// <param name="request">The REST request to call.</param>
-        protected AbstractRestQuestion(IRestRequest request) => Request = request;
+        protected AbstractRestQuestion(RestRequest request) => Request = request;
 
         #endregion
 
@@ -39,7 +39,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="client">The RestSharp client.</param>
         /// <returns></returns>
-        protected abstract IRestResponse Execute(IRestClient client);
+        protected abstract RestResponse Execute(RestClient client);
 
         /// <summary>
         /// Calls the Question.
@@ -106,11 +106,11 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="actor">The Screenplay Actor.</param>
         /// <returns></returns>
-        protected IRestResponse CallRequest(IActor actor)
+        protected RestResponse CallRequest(IActor actor)
         {
             // Prepare variables
             var ability = actor.Using<TAbility>();
-            IRestResponse response = null;
+            RestResponse response = null;
             DateTime? start = null;
             DateTime? end = null;
 

--- a/Boa.Constrictor.RestSharp/Interactions/Rest.cs
+++ b/Boa.Constrictor.RestSharp/Interactions/Rest.cs
@@ -14,7 +14,7 @@ namespace Boa.Constrictor.RestSharp
         /// <param name="request">The REST request to call.</param>
         /// <param name="fileExtension">The extension for the file to download.</param>
         /// <returns></returns>
-        public static RestApiDownload<CallRestApi> Download(IRestRequest request, string fileExtension = null) =>
+        public static RestApiDownload<CallRestApi> Download(RestRequest request, string fileExtension = null) =>
             new RestApiDownload<CallRestApi>(request, fileExtension);
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="request">The REST request to call.</param>
         /// <returns></returns>
-        public static RestApiCall<CallRestApi> Request(IRestRequest request) =>
+        public static RestApiCall<CallRestApi> Request(RestRequest request) =>
             new RestApiCall<CallRestApi>(request);
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Boa.Constrictor.RestSharp
         /// <param name="request">The REST request to call.</param>
         /// <typeparam name="TData">The response data type for deserialization.</typeparam>
         /// <returns></returns>
-        public static RestApiCall<CallRestApi, TData> Request<TData>(IRestRequest request) =>
+        public static RestApiCall<CallRestApi, TData> Request<TData>(RestRequest request) =>
             new RestApiCall<CallRestApi, TData>(request);
     }
 
@@ -50,7 +50,7 @@ namespace Boa.Constrictor.RestSharp
         /// <param name="request">The REST request to call.</param>
         /// <param name="fileExtension">The extension for the file to download.</param>
         /// <returns></returns>
-        public static RestApiDownload<TAbility> Download(IRestRequest request, string fileExtension = null) =>
+        public static RestApiDownload<TAbility> Download(RestRequest request, string fileExtension = null) =>
             new RestApiDownload<TAbility>(request, fileExtension);
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="request">The REST request to call.</param>
         /// <returns></returns>
-        public static RestApiCall<TAbility> Request(IRestRequest request) =>
+        public static RestApiCall<TAbility> Request(RestRequest request) =>
             new RestApiCall<TAbility>(request);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Boa.Constrictor.RestSharp
         /// <param name="request">The REST request to call.</param>
         /// <typeparam name="TData">The response data type for deserialization.</typeparam>
         /// <returns></returns>
-        public static RestApiCall<TAbility, TData> Request<TData>(IRestRequest request) =>
+        public static RestApiCall<TAbility, TData> Request<TData>(RestRequest request) =>
             new RestApiCall<TAbility, TData>(request);
     }
 }

--- a/Boa.Constrictor.RestSharp/Interactions/RestApiCall.cs
+++ b/Boa.Constrictor.RestSharp/Interactions/RestApiCall.cs
@@ -10,7 +10,7 @@ namespace Boa.Constrictor.RestSharp
     /// Automatically dumps requests and responses if the Ability has a dumper.
     /// </summary>
     /// <typeparam name="TAbility">The RestSharp Ability type.</typeparam>
-    public class RestApiCall<TAbility> : AbstractRestQuestion<TAbility, IRestResponse>
+    public class RestApiCall<TAbility> : AbstractRestQuestion<TAbility, RestResponse>
         where TAbility : IRestSharpAbility
     {
         #region Constructors
@@ -20,7 +20,7 @@ namespace Boa.Constrictor.RestSharp
         /// (Use the Rest class to construct the Question.)
         /// </summary>
         /// <param name="request">The REST request to call.</param>
-        internal RestApiCall(IRestRequest request) : base(request) { }
+        internal RestApiCall(RestRequest request) : base(request) { }
 
         #endregion
 
@@ -31,14 +31,14 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="client">The RestSharp client.</param>
         /// <returns></returns>
-        protected override IRestResponse Execute(IRestClient client) => client.Execute(Request);
+        protected override RestResponse Execute(RestClient client) => client.Execute(Request);
 
         /// <summary>
         /// Calls the REST request and returns the response.
         /// </summary>
         /// <param name="actor">The Screenplay Actor.</param>
         /// <returns></returns>
-        public override IRestResponse RequestAs(IActor actor) => CallRequest(actor);
+        public override RestResponse RequestAs(IActor actor) => CallRequest(actor);
 
 
 
@@ -118,7 +118,7 @@ namespace Boa.Constrictor.RestSharp
     /// </summary>
     /// <typeparam name="TAbility">The RestSharp Ability type.</typeparam>
     /// <typeparam name="TData">The data deserialization object type.</typeparam>
-    public class RestApiCall<TAbility, TData> : AbstractRestQuestion<TAbility, IRestResponse<TData>>
+    public class RestApiCall<TAbility, TData> : AbstractRestQuestion<TAbility, RestResponse<TData>>
         where TAbility : IRestSharpAbility
     {
         #region Constructors
@@ -128,7 +128,7 @@ namespace Boa.Constrictor.RestSharp
         /// (Use the Rest class to construct the Question.)
         /// </summary>
         /// <param name="request">The REST request to call.</param>
-        internal RestApiCall(IRestRequest request) : base(request) { }
+        internal RestApiCall(RestRequest request) : base(request) { }
 
         #endregion
 
@@ -139,14 +139,14 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="client">The RestSharp client.</param>
         /// <returns></returns>
-        protected override IRestResponse Execute(IRestClient client) => client.Execute<TData>(Request);
+        protected override RestResponse Execute(RestClient client) => client.Execute<TData>(Request);
 
         /// <summary>
         /// Calls the REST request and returns the response with deserialized data.
         /// </summary>
         /// <param name="actor">The Screenplay Actor.</param>
         /// <returns></returns>
-        public override IRestResponse<TData> RequestAs(IActor actor) => (IRestResponse<TData>)CallRequest(actor);
+        public override RestResponse<TData> RequestAs(IActor actor) => (RestResponse<TData>)CallRequest(actor);
 
         #endregion
     }

--- a/Boa.Constrictor.RestSharp/Interactions/RestApiDownload.cs
+++ b/Boa.Constrictor.RestSharp/Interactions/RestApiDownload.cs
@@ -30,7 +30,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="request">The REST request to call.</param>
         /// <param name="fileExtension">The extension for the file to download.</param>
-        internal RestApiDownload(IRestRequest request, string fileExtension = null) :
+        internal RestApiDownload(RestRequest request, string fileExtension = null) :
             base(request) => FileExtension = fileExtension;
 
         #endregion
@@ -42,7 +42,7 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="client">The RestSharp client.</param>
         /// <returns></returns>
-        protected override IRestResponse Execute(IRestClient client) => client.Execute(Request);
+        protected override RestResponse Execute(RestClient client) => client.Execute(Request);
 
         /// <summary>
         /// Calls the REST request and returns the downloaded file data as a byte array.

--- a/Boa.Constrictor.RestSharp/Serialization/FullRestData.cs
+++ b/Boa.Constrictor.RestSharp/Serialization/FullRestData.cs
@@ -45,9 +45,9 @@ namespace Boa.Constrictor.RestSharp
         /// <param name="start">Request's start time.</param>
         /// <param name="end">Request's end time.</param>
         public FullRestData(
-            IRestClient client,
-            IRestRequest request = null,
-            IRestResponse response = null,
+            RestClient client,
+            RestRequest request = null,
+            RestResponse response = null,
             DateTime? start = null,
             DateTime? end = null)
         {
@@ -66,14 +66,14 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="client">RestSharp client.</param>
         /// <returns></returns>
-        private IList<Cookie> GetCookieData(IRestClient client)
+        private IList<Cookie> GetCookieData(RestClient client)
         {
             // Linq cannot be used because CookieCollection does not use generic typing.
             // Thus, we suffer with the foreach loop below.
 
             IList<Cookie> cookies = new List<Cookie>();
 
-            foreach (var c in client.CookieContainer.GetCookies(client.BaseUrl))
+            foreach (var c in client.CookieContainer.GetCookies(client.Options.BaseUrl))
                 cookies.Add((Cookie)c);
 
             return cookies;

--- a/Boa.Constrictor.RestSharp/Serialization/ParameterData.cs
+++ b/Boa.Constrictor.RestSharp/Serialization/ParameterData.cs
@@ -33,11 +33,11 @@ namespace Boa.Constrictor.RestSharp
         #pragma warning disable 0618
 
         /// <summary>
-        /// Converts a list of parameters to a serializable object.
+        /// Converts a collection of parameters to a serializable object.
         /// </summary>
-        /// <param name="parameters">The list of parameters.</param>
+        /// <param name="parameters">The collection of parameters.</param>
         /// <returns></returns>
-        public static IList<ParameterData> GetParameterDataList(IList<Parameter> parameters) =>
+        public static IList<ParameterData> GetParameterDataList(IReadOnlyCollection<Parameter> parameters) =>
             parameters.Select(p => new ParameterData
             {
                 Name = p.Name,
@@ -45,7 +45,7 @@ namespace Boa.Constrictor.RestSharp
                 Type = p.Type.ToString()
             }).ToList();
 
-        #pragma warning restore 0618
+#pragma warning restore 0618
 
         #endregion
     }

--- a/Boa.Constrictor.RestSharp/Serialization/RequestData.cs
+++ b/Boa.Constrictor.RestSharp/Serialization/RequestData.cs
@@ -1,6 +1,7 @@
 ﻿using RestSharp;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Boa.Constrictor.RestSharp
 {
@@ -34,7 +35,7 @@ namespace Boa.Constrictor.RestSharp
         /// <summary>
         /// Request body.
         /// </summary>
-        public RequestBody Body { get; set; }
+        public Parameter Body { get; set; }
 
         #endregion
 
@@ -44,13 +45,13 @@ namespace Boa.Constrictor.RestSharp
         /// Constructor.
         /// </summary>
         /// <param name="request">Request object.</param>
-        public RequestData(IRestRequest request)
+        public RequestData(RestRequest request)
         {
             Method = request.Method.ToString();
             Uri = null;
             Resource = request.Resource;
             Parameters = ParameterData.GetParameterDataList(request.Parameters);
-            Body = request.Body;
+            Body = request.Parameters.FirstOrDefault(p => p.Type == ParameterType.RequestBody);
         }
 
         /// <summary>
@@ -58,13 +59,13 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="client">RestSharp client.</param>
         /// <param name="request">Request object.</param>
-        public RequestData(IRestRequest request, IRestClient client)
+        public RequestData(RestRequest request, RestClient client)
         {
             Method = request.Method.ToString();
             Uri = client.BuildUri(request);
             Resource = request.Resource;
             Parameters = ParameterData.GetParameterDataList(request.Parameters);
-            Body = request.Body;
+            Body = request.Parameters.FirstOrDefault(p => p.Type == ParameterType.RequestBody);
         }
 
         #endregion

--- a/Boa.Constrictor.RestSharp/Serialization/ResponseData.cs
+++ b/Boa.Constrictor.RestSharp/Serialization/ResponseData.cs
@@ -45,7 +45,7 @@ namespace Boa.Constrictor.RestSharp
         /// Constructor.
         /// </summary>
         /// <param name="response">Response object.</param>
-        public ResponseData(IRestResponse response)
+        public ResponseData(RestResponse response)
         {
             Uri = response.ResponseUri;
             StatusCode = response.StatusCode;


### PR DESCRIPTION
## Description
Hello!

There was talks in the discord about updating to the latest RestSharp so I went ahead and did it :)
	
- All instances of the following interfaces have been replaced with concrete classes
    - `IRestClient` -> `RestClient`
    - `IRestRequest` -> `RestRequest`
    - `IRestResponse` -> `RestResponse`
- See the [Migration Guide](https://restsharp.dev/v107/#brief-migration-guide) for more details
- Changed `RequestDumper` serialization to support RestSharp 108.3
- Fixed unit tests. Replaced the use of Moq with MockHttp where necessary as recommended [here](https://restsharp.dev/v107/#mocking)
- THIS IS A BREAKING CHANGE. Users will need to use the concrete classes and refactor clients + requests to use the new object models

## Testing

- Ran the example project to ensure basic requests work as expected
- I refactored the serialization unit tests but tried to keep the assertions the same as best I could. I don't fully understand the goal of each test and I feel like these could be refactored to more explicit requirements but regardless, they all pass.
- I was surprised to find there are no tests that cover request dumping. I didn't write my own as I didn't create this feature but I did manually verify that requests are dumped using the example project

## Checklist

- [X] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [X] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [X] I successfully built the .NET solution with no errors or new warnings.
- [X] I successfully ran both the unit tests and the example tests.
- [X] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [X] I added documentation for these changes (if appropriate).
