### PR TITLE
Bug fixes/255 answer logs actor name

### DIFF
--- a/Boa.Constrictor.Screenplay.UnitTests/Screenplay/Pattern/ActorTest.cs
+++ b/Boa.Constrictor.Screenplay.UnitTests/Screenplay/Pattern/ActorTest.cs
@@ -92,10 +92,10 @@ namespace Boa.Constrictor.Screenplay.UnitTests
         [Test]
         public void ActorNameLoggedForAnswer()
         {
-            string responseMessage = string.Empty;
-            bool hasAskedQuestion = false;
+            var responseMessage = string.Empty;
+            var hasAskedQuestion = false;
 
-            Mock<ILogger> MockLogger = new Mock<ILogger>();
+            var MockLogger = new Mock<ILogger>();
 
             MockLogger.Setup(x => x.Info(It.IsAny<string>()))
                 .Callback<string>(message =>
@@ -110,11 +110,42 @@ namespace Boa.Constrictor.Screenplay.UnitTests
                     }
                 });
 
-            Mock<IQuestion<bool>> MockQuestion = new Mock<IQuestion<bool>>();
-            MockQuestion.Setup(x => x.ToString()).Returns("'OkButton' Enabled");
+            var MockQuestion = new Mock<IQuestion<bool>>();
+            MockQuestion.Setup(x => x.ToString()).Returns("appearance of 'OkButton'");
 
-            Actor joe = new Actor("Joe", MockLogger.Object);
+            var joe = new Actor("Joe", MockLogger.Object);
             joe.AsksFor(MockQuestion.Object);
+
+            responseMessage.Should().StartWith("Screenplay Actor 'Joe' observed that the");
+        }
+
+        [Test]
+        public async Task ActorNameLoggedForAnswerAsync()
+        {
+            var responseMessage = string.Empty;
+            var hasAskedQuestion = false;
+
+            var MockLogger = new Mock<ILogger>();
+
+            MockLogger.Setup(x => x.Info(It.IsAny<string>()))
+                .Callback<string>(message =>
+                {
+                    if (hasAskedQuestion)
+                    {
+                        responseMessage = message;
+                    }
+                    else
+                    {
+                        hasAskedQuestion = true;
+                    }
+                });
+
+            var MockQuestion = new Mock<IQuestionAsync<bool>>();
+            MockQuestion.Setup(x => x.RequestAsAsync(It.IsAny<IActor>())).ReturnsAsync(true);
+            MockQuestion.Setup(x => x.ToString()).Returns("appearance of 'OkButton'");
+
+            var joe = new Actor("Joe", MockLogger.Object);
+            _ = await joe.AsksForAsync(MockQuestion.Object);
 
             responseMessage.Should().StartWith("Screenplay Actor 'Joe' observed that the");
         }

--- a/Boa.Constrictor.Screenplay.UnitTests/Screenplay/Pattern/ActorTest.cs
+++ b/Boa.Constrictor.Screenplay.UnitTests/Screenplay/Pattern/ActorTest.cs
@@ -1,5 +1,4 @@
-﻿using Boa.Constrictor.Screenplay;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using System.Threading.Tasks;
@@ -91,6 +90,36 @@ namespace Boa.Constrictor.Screenplay.UnitTests
         }
 
         [Test]
+        public void ActorNameLoggedForAnswer()
+        {
+            string responseMessage = string.Empty;
+            bool hasAskedQuestion = false;
+
+            Mock<ILogger> MockLogger = new Mock<ILogger>();
+
+            MockLogger.Setup(x => x.Info(It.IsAny<string>()))
+                .Callback<string>(message =>
+                {
+                    if (hasAskedQuestion)
+                    {
+                        responseMessage = message;
+                    }
+                    else
+                    {
+                        hasAskedQuestion = true;
+                    }
+                });
+
+            Mock<IQuestion<bool>> MockQuestion = new Mock<IQuestion<bool>>();
+            MockQuestion.Setup(x => x.ToString()).Returns("'OkButton' Enabled");
+
+            Actor joe = new Actor("Joe", MockLogger.Object);
+            joe.AsksFor(MockQuestion.Object);
+
+            responseMessage.Should().StartWith("Screenplay Actor 'Joe' observed that the");
+        }
+
+        [Test]
         public async Task AsksForAsync()
         {
             var MockQuestion = new Mock<IQuestionAsync<bool>>();
@@ -99,7 +128,6 @@ namespace Boa.Constrictor.Screenplay.UnitTests
             answer.Should().BeTrue();
         }
 
-        [Test]
         public void AskingFor()
         {
             var MockQuestion = new Mock<IQuestion<bool>>();

--- a/Boa.Constrictor.Screenplay/CHANGELOG.md
+++ b/Boa.Constrictor.Screenplay/CHANGELOG.md
@@ -17,7 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+### Added
+
+### Changed
+
+- Log entry now includes the following prefix when an `Interaction` answer is received:
+   - `{ActorName} observed that the`
 
 
 ## [3.0.3] - 2022-12-13
@@ -30,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Created separate changelog files for each project (except unit tests).
 - Converted `AnswerCache` to use a `Hashtable` instead of a pointlessly generic `IDictionary`
-
 
 ## [3.0.2] - 2022-12-07
 

--- a/Boa.Constrictor.Screenplay/Screenplay/Pattern/Actor.cs
+++ b/Boa.Constrictor.Screenplay/Screenplay/Pattern/Actor.cs
@@ -63,14 +63,15 @@ namespace Boa.Constrictor.Screenplay
         /// </summary>
         /// <typeparam name="TAnswer">The answer type.</typeparam>
         /// <param name="question">The Question to ask.</param>
-        /// <param name="enterPhrase">The phrase to print before calling.</param>
-        /// <param name="exitPhrase">The phrase to print after calling.</param>
+        /// <param name="observationPhrase">The phrase to log when a response is received.</param>
+        /// <param name="enterPhrase">The phrase to log before calling.</param>
+        /// <param name="exitPhrase">The phrase to log after calling.</param>
         /// <returns></returns>
-        private TAnswer CallQuestion<TAnswer>(IQuestion<TAnswer> question, string enterPhrase, string exitPhrase)
+        private TAnswer CallQuestion<TAnswer>(IQuestion<TAnswer> question, string observationPhrase, string enterPhrase, string exitPhrase)
         {
             Logger.Info($"{this} {enterPhrase} {question}");
             TAnswer answer = question.RequestAs(this);
-            Logger.Info($"{question} {exitPhrase} {answer}");
+            Logger.Info($"{this} {observationPhrase} {question} {exitPhrase} {answer}");
             return answer;
         }
 
@@ -129,7 +130,7 @@ namespace Boa.Constrictor.Screenplay
         /// <returns></returns>
         public TAnswer AsksFor<TAnswer>(IQuestion<TAnswer> question)
         {
-            return CallQuestion(question, "asks for", "was");
+            return CallQuestion(question, "observed that the", "asks for", "was");
         }
 
         /// <summary>
@@ -153,7 +154,7 @@ namespace Boa.Constrictor.Screenplay
         /// <returns></returns>
         public TAnswer AskingFor<TAnswer>(IQuestion<TAnswer> question)
         {
-            return CallQuestion(question, "asking for", "was");
+            return CallQuestion(question, "observed that the", "asking for", "was");
         }
 
         /// <summary>
@@ -207,7 +208,7 @@ namespace Boa.Constrictor.Screenplay
         /// <param name="question">The Question to ask.</param>
         public TAnswer Calls<TAnswer>(IQuestion<TAnswer> question)
         {
-            return CallQuestion(question, "calls", "returned:");
+            return CallQuestion(question, "observed that the", "calls", "returned:");
         }
 
         /// <summary>

--- a/Boa.Constrictor.Screenplay/Screenplay/Pattern/Actor.cs
+++ b/Boa.Constrictor.Screenplay/Screenplay/Pattern/Actor.cs
@@ -80,14 +80,15 @@ namespace Boa.Constrictor.Screenplay
         /// </summary>
         /// <typeparam name="TAnswer">The answer type.</typeparam>
         /// <param name="question">The Question to ask.</param>
-        /// <param name="enterPhrase">The phrase to print before calling.</param>
-        /// <param name="exitPhrase">The phrase to print after calling.</param>
+        /// <param name="observationPhrase">The phrase to log when a response is received.</param>
+        /// <param name="enterPhrase">The phrase to log before calling.</param>
+        /// <param name="exitPhrase">The phrase to log after calling.</param>
         /// <returns></returns>
-        private async Task<TAnswer> CallQuestionAsync<TAnswer>(IQuestionAsync<TAnswer> question, string enterPhrase, string exitPhrase)
+        private async Task<TAnswer> CallQuestionAsync<TAnswer>(IQuestionAsync<TAnswer> question, string observationPhrase, string enterPhrase, string exitPhrase)
         {
             Logger.Info($"{this} {enterPhrase} {question}");
             TAnswer answer = await question.RequestAsAsync(this);
-            Logger.Info($"{question} {exitPhrase} {answer}");
+            Logger.Info($"{this} {observationPhrase} {question} {exitPhrase} {answer}");
             return answer;
         }
 
@@ -142,7 +143,7 @@ namespace Boa.Constrictor.Screenplay
         /// <returns></returns>
         public async Task<TAnswer> AsksForAsync<TAnswer>(IQuestionAsync<TAnswer> question)
         {
-            return await CallQuestionAsync(question, "asks for", "was");
+            return await CallQuestionAsync(question, "observed that the", "asks for", "was");
         }
 
         /// <summary>
@@ -166,7 +167,7 @@ namespace Boa.Constrictor.Screenplay
         /// <returns></returns>
         public async Task<TAnswer> AskingForAsync<TAnswer>(IQuestionAsync<TAnswer> question)
         {
-            return await CallQuestionAsync(question, "asking for", "was");
+            return await CallQuestionAsync(question, "observed that the", "asking for", "was");
         }
 
         /// <summary>
@@ -219,7 +220,7 @@ namespace Boa.Constrictor.Screenplay
         /// <param name="question">The Question to ask.</param>
         public async Task<TAnswer> CallsAsync<TAnswer>(IQuestionAsync<TAnswer> question)
         {
-            return await CallQuestionAsync(question, "calls", "returned:");
+            return await CallQuestionAsync(question, "observed that the", "calls", "returned:");
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Summary of changes:

1. Improved `Actor` logging.
2. Added unit tests.

Sample output now looks like:

```Batch
Screenplay Actor 'Joe' observed that the appearance of 'OkButton' was False
Screenplay Actor 'Joe' observed that the appearance of 'OkButton' returned: False
```

## Testing

Added unit tests to `ActorTest.cs`

- `ActorNameLoggedForAnswer()` : ensures log message includes `Actor`'s name when receiving a response.
- `ActorNameLoggedForAnswerAsync()` : ensures log message includes `Actor`'s name when receiving a response (for ASYNC)

## Checklist

- [X] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [X] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [X] I successfully built the .NET solution with no errors or new warnings.
- [X] I successfully ran both the unit tests and the example tests.
   - [X] The 2 newly created tests also passed.
- [X] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [X] I added documentation for these changes (if appropriate).
