### PR TITLE
 Update RestSharp to 110.2.0

### DIFF
--- a/Boa.Constrictor.RestSharp.UnitTests/Serialization/FullRestDataTest.cs
+++ b/Boa.Constrictor.RestSharp.UnitTests/Serialization/FullRestDataTest.cs
@@ -65,7 +65,8 @@ namespace Boa.Constrictor.RestSharp.UnitTests
                 new RestClientOptions
                 {
                     ConfigureMessageHandler = _ => mockHttp,
-                    BaseUrl = ClientUri
+                    BaseUrl = ClientUri,
+                    CookieContainer = new CookieContainer()
                 }
             );
 
@@ -99,7 +100,7 @@ namespace Boa.Constrictor.RestSharp.UnitTests
         [Test]
         public void InitCookiesOnly()
         {
-            Client.CookieContainer.Add(ClientUri, Cookie);
+            Client.Options.CookieContainer.Add(ClientUri, Cookie);
 
             var data = new FullRestData(Client);
 
@@ -159,7 +160,7 @@ namespace Boa.Constrictor.RestSharp.UnitTests
         [Test]
         public void InitRequestOnly()
         {
-            Client.CookieContainer.Add(ClientUri, Cookie);
+            Client.Options.CookieContainer.Add(ClientUri, Cookie);
             DateTime start = DateTime.UtcNow;
             var data = new FullRestData(Client, Request, start: start);
 
@@ -185,7 +186,7 @@ namespace Boa.Constrictor.RestSharp.UnitTests
         [Test]
         public void InitRequestAndResponse()
         {
-            Client.CookieContainer.Add(ClientUri, Cookie);
+            Client.Options.CookieContainer.Add(ClientUri, Cookie);
             DateTime start = DateTime.UtcNow;
             DateTime end = start.AddSeconds(1);
             var data = new FullRestData(Client, Request, Response, start, end);

--- a/Boa.Constrictor.RestSharp/Abilities/AbstractRestSharpAbility.cs
+++ b/Boa.Constrictor.RestSharp/Abilities/AbstractRestSharpAbility.cs
@@ -33,9 +33,6 @@ namespace Boa.Constrictor.RestSharp
             Client = client;
             RequestDumper = null;
             DownloadDumper = null;
-
-            if (Client.Options.CookieContainer == null)
-                Client.Options.CookieContainer = new CookieContainer();
         }
 
         /// <summary>
@@ -86,7 +83,15 @@ namespace Boa.Constrictor.RestSharp
         /// Adds a cookie to the RestSharp client.
         /// </summary>
         /// <param name="cookie">The cookie to add to the RestSharp client.</param>
-        public void AddCookie(Cookie cookie) => Client.CookieContainer.Add(cookie);
+        public void AddCookie(Cookie cookie)
+        {
+            if (Client.Options.CookieContainer == null)
+            {
+                throw new RestApiException("Client CookieContainer is not initialized");
+            }
+
+            Client.Options.CookieContainer.Add(cookie);
+        }
 
         /// <summary>
         /// Checks if downloads can be dumped.
@@ -106,7 +111,15 @@ namespace Boa.Constrictor.RestSharp
         /// </summary>
         /// <param name="name">The cookie name.</param>
         /// <returns></returns>
-        public Cookie GetCookie(string name) => Client.CookieContainer.GetCookies(Client.Options.BaseUrl)[name];
+        public Cookie GetCookie(string name)
+        {
+            if (Client.Options.CookieContainer == null)
+            {
+                throw new RestApiException("Client CookieContainer is not initialized");
+            }
+
+            return Client.Options.CookieContainer.GetCookies(Client.Options.BaseUrl)[name];
+        }
 
         /// <summary>
         /// Returns a description of this Ability.

--- a/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
+++ b/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="108.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">

--- a/Boa.Constrictor.RestSharp/CHANGELOG.md
+++ b/Boa.Constrictor.RestSharp/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
-
+- Updated RestSharp to 110.2.0
+- Changed `RequestDumper` to support RestSharp 110.2.0
+- Fixed unit tests. Callers must now initialize the `CookieContainer` themselves in `RestClientOptions`
 
 ## [3.1.0] - 2023-05-24
 

--- a/Boa.Constrictor.RestSharp/Serialization/FullRestData.cs
+++ b/Boa.Constrictor.RestSharp/Serialization/FullRestData.cs
@@ -73,7 +73,9 @@ namespace Boa.Constrictor.RestSharp
 
             IList<Cookie> cookies = new List<Cookie>();
 
-            foreach (var c in client.CookieContainer.GetCookies(client.Options.BaseUrl))
+            if (client.Options.CookieContainer == null) return cookies;
+
+            foreach (var c in client.Options.CookieContainer.GetCookies(client.Options.BaseUrl))
                 cookies.Add((Cookie)c);
 
             return cookies;


### PR DESCRIPTION
Throw a better exception if cookie container isn't initialized

## Description

Updated RestSharp to the latest version.

There was one breaking change: `Client.CookieContainer` is now `Client.Options.CookieContainer`
Options are now read-only so once your client is initialized you can no longer modify them.

I had to make a couple changes to accommodate this:

1. `AbstractRestSharpAbility` can no longer initialize the `CookieContainer` if it's null. I log exceptions where necessary to hopefully make this more obvious to the caller. It's only mandatory if the caller is making use of `restAbility.AddCookie()` / `GetCookie()`
2. During request dumping if the `CookieContainer` is null, dump an empty list of cookies.



## Testing

All unit tests pass
I manually tested that request dumping was working using the example project



## Checklist

- [X] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [X] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [X] I successfully built the .NET solution with no errors or new warnings.
- [X] I successfully ran both the unit tests and the example tests.
- [X] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [X] I added documentation for these changes (if appropriate).
