### PR TITLE
Enhancement/boa constrictor 273 close web driver

### DIFF
--- a/Boa.Constrictor.Selenium/CHANGELOG.md
+++ b/Boa.Constrictor.Selenium/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+### Added
+
+- Added `CloseWebDriver` to `Boa.Constrictor.Screenplay` to enable closing the active window or tab
 
 
 ## [4.1.0] - 2024-01-29

--- a/Boa.Constrictor.Selenium/Tasks/CloseWebDriver.cs
+++ b/Boa.Constrictor.Selenium/Tasks/CloseWebDriver.cs
@@ -1,0 +1,49 @@
+﻿using Boa.Constrictor.Screenplay;
+using OpenQA.Selenium;
+
+namespace Boa.Constrictor.Selenium
+{
+    /// <summary>
+    /// Closes the WebDriver window or tab.
+    /// </summary>
+    public class CloseWebDriver : AbstractWebTask
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Private constructor.
+        /// (Use static builder methods to construct.)
+        /// </summary>
+        private CloseWebDriver() { }
+
+        #endregion
+
+        #region Builder Methods
+
+        /// <summary>
+        /// Constructs the Task object.
+        /// </summary>
+        /// <returns></returns>
+        public static CloseWebDriver ForBrowser() => new CloseWebDriver();
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Closes the WebDriver window or tab.
+        /// WARNING: You must switch back to a valid window handle in order to continue execution
+        /// </summary>
+        /// <param name="actor">The Screenplay Actor.</param>
+        /// <param name="driver">The WebDriver.</param>
+        public override void PerformAs(IActor actor, IWebDriver driver) => driver.Close();
+
+        /// <summary>
+        /// Returns a description of the Task.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => "close the WebDriver window or tab";
+
+        #endregion
+    }
+}

--- a/Boa.Constrictor.Xunit/CHANGELOG.md
+++ b/Boa.Constrictor.Xunit/CHANGELOG.md
@@ -7,7 +7,7 @@ Its format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Unreleased]
 ### Added
 
-- Added `CloseWebDriver` to `Boa.Constrictor.Screenplay` to enable closing the active tab window or tab
+- Added `CloseWebDriver` to `Boa.Constrictor.Screenplay` to enable closing the active window or tab
 
 ## [4.1.0] - 2024-04-15
 ### Added

--- a/Boa.Constrictor.Xunit/CHANGELOG.md
+++ b/Boa.Constrictor.Xunit/CHANGELOG.md
@@ -5,11 +5,11 @@ This file documents all notable changes to the Boa.Constrictor.Xunit project and
 Its format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
-### Added
 
-- Added `CloseWebDriver` to `Boa.Constrictor.Screenplay` to enable closing the active window or tab
+(none)
 
 ## [4.1.0] - 2024-04-15
+
 ### Added
 
 - Added `MessageSinkLogger` for logging in xUnit extensibility classes

--- a/Boa.Constrictor.Xunit/CHANGELOG.md
+++ b/Boa.Constrictor.Xunit/CHANGELOG.md
@@ -5,7 +5,9 @@ This file documents all notable changes to the Boa.Constrictor.Xunit project and
 Its format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
-(none)
+### Added
+
+- Added `CloseWebDriver` to `Boa.Constrictor.Screenplay` to enable closing the active tab window or tab
 
 ## [4.1.0] - 2024-04-15
 ### Added


### PR DESCRIPTION
## Description

 Adding a task to close the current window or tab [using the WebDriver .Close() function ](https://www.selenium.dev/documentation/webdriver/interactions/windows/#closing-a-window-or-tab)

This functionality enables a solution for an issue some are experiencing with Chrome 124+ and ChromeDriver where orphan windows are not closed with Quit().  https://github.com/q2ebanking/boa-constrictor/issues/273 but has general utility 

This issue is a nightmare for running tests in parallel and affecting our workflow!

## Testing

The time sequence in the Windows Task Manager demonstrates two Chrome Browser windows running, one closing and finally the WebDriver quitting. My window for this pull request  ^_^ is `Google Chrome (8)` my test's window is `Google Chrome (7)`. When the Close() command is called `Google Chrome (7)` terminates. When the Quit() command is called the `Chromedriver (32 bit)` terminates. 
<img width="200" alt="Screenshot 2024-06-10 at 1 57 03 PM" src="https://github.com/q2ebanking/boa-constrictor/assets/60014419/fda444e5-52c1-4b6a-80ae-234b3c2f1805">
<img width="200" alt="Screenshot 2024-06-10 at 1 57 51 PM" src="https://github.com/q2ebanking/boa-constrictor/assets/60014419/660436a5-761e-4afc-8b31-a6e0a7f0282a">
<img width="200" alt="Screenshot 2024-06-10 at 1 58 33 PM" src="https://github.com/q2ebanking/boa-constrictor/assets/60014419/ae4322d8-902e-44fc-8e5d-4ea9e8587dc7">


### Unit Tests
<img width="281" alt="image" src="https://github.com/q2ebanking/boa-constrictor/assets/60014419/dee89264-97fa-431b-b55e-a4d28f5675d1">

## Checklist

- [x ] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [ x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [ x] I successfully built the .NET solution with no errors or new warnings.
- [ x] I successfully ran both the unit tests and the example tests.
- [ x] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [ x] I added documentation for these changes (if appropriate).
