### PR TITLE
Update Selenium packages for Null Pointer vulnerability

### DIFF
--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
 
 
       # Screenplay

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build the solution
         run: dotnet build
@@ -38,7 +38,7 @@ jobs:
 
       - name: Archive Screenplay unit test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Screenplay unit test results
           path: Boa.Constrictor.Screenplay.UnitTests/TestResults/ScreenplayResults.trx
@@ -46,7 +46,7 @@ jobs:
 
       - name: Archive Selenium unit test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Selenium unit test results
           path: Boa.Constrictor.Selenium.UnitTests/TestResults/SeleniumResults.trx
@@ -54,7 +54,7 @@ jobs:
 
       - name: Archive RestSharp unit test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: RestSharp unit test results
           path: Boa.Constrictor.RestSharp.UnitTests/TestResults/RestSharpResults.trx
@@ -62,7 +62,7 @@ jobs:
 
       - name: Archive Xunit unit test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Xunit unit test results
           path: Boa.Constrictor.Xunit.UnitTests/TestResults/XunitResults.trx

--- a/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
+++ b/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>4.0.0</Version>
     <Authors>Pandy Knight and the PrecisionLender SETs</Authors>
     <Company>Q2</Company>

--- a/Boa.Constrictor.RestSharp.UnitTests/Boa.Constrictor.RestSharp.UnitTests.csproj
+++ b/Boa.Constrictor.RestSharp.UnitTests/Boa.Constrictor.RestSharp.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Boa.Constrictor.Screenplay.UnitTests/Boa.Constrictor.Screenplay.UnitTests.csproj
+++ b/Boa.Constrictor.Screenplay.UnitTests/Boa.Constrictor.Screenplay.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Boa.Constrictor.Selenium.UnitTests/Boa.Constrictor.Selenium.UnitTests.csproj
+++ b/Boa.Constrictor.Selenium.UnitTests/Boa.Constrictor.Selenium.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Boa.Constrictor.Selenium.UnitTests/Equality/WebInteractionEqualityTest.cs
+++ b/Boa.Constrictor.Selenium.UnitTests/Equality/WebInteractionEqualityTest.cs
@@ -1,5 +1,4 @@
 ﻿using Boa.Constrictor.Screenplay;
-using Boa.Constrictor.Selenium;
 using FluentAssertions;
 using NUnit.Framework;
 using OpenQA.Selenium;
@@ -34,8 +33,8 @@ namespace Boa.Constrictor.Selenium.UnitTests
             new object[] { CssValueList.For(LocatorA, "property"), CssValueList.For(LocatorA1, "property") },
             new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot"), CurrentScreenshot.SavedTo("/path/to/screenshot") },
             new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot", "file"), CurrentScreenshot.SavedTo("/path/to/screenshot", "file") },
-            new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot", "file").UsingFormat(ScreenshotImageFormat.Png), CurrentScreenshot.SavedTo("/path/to/screenshot", "file").UsingFormat(ScreenshotImageFormat.Png) },
-            new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(ScreenshotImageFormat.Png), CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(ScreenshotImageFormat.Png) },
+            new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot", "file").UsingFormat(".png"), CurrentScreenshot.SavedTo("/path/to/screenshot", "file").UsingFormat(".png") },
+            new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(".png"), CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(".png") },
             new object[] { CurrentUrl.FromBrowser(), CurrentUrl.FromBrowser() },
             new object[] { DomProperty.Of(LocatorA, "property"), DomProperty.Of(LocatorA1, "property") },
             new object[] { EnabledState.Of(LocatorA), EnabledState.Of(LocatorA1) },
@@ -127,7 +126,7 @@ namespace Boa.Constrictor.Selenium.UnitTests
             new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot"), CurrentScreenshot.SavedTo("/path/to/screenshot2") },
             new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot", "file"), CurrentScreenshot.SavedTo("/path/to/screenshot") },
             new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot", "file"), CurrentScreenshot.SavedTo("/path/to/screenshot", "file2") },
-            new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(ScreenshotImageFormat.Png), CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(ScreenshotImageFormat.Jpeg) },
+            new object[] { CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(".png"), CurrentScreenshot.SavedTo("/path/to/screenshot").UsingFormat(".jpeg") },
             new object[] { CurrentUrl.FromBrowser(), Title.OfPage() },
             new object[] { DomProperty.Of(LocatorA, "property"), Title.OfPage() },
             new object[] { DomProperty.Of(LocatorA, "property"), DomProperty.Of(LocatorB, "property") },

--- a/Boa.Constrictor.Selenium.UnitTests/Questions/CurrentScreenshotTest.cs
+++ b/Boa.Constrictor.Selenium.UnitTests/Questions/CurrentScreenshotTest.cs
@@ -76,7 +76,7 @@ namespace Boa.Constrictor.Selenium.UnitTests
         [Test]
         public void TestSaveFileWithJpegFormat()
         {
-            var image = Actor.AsksFor(CurrentScreenshot.SavedTo(Dir, "webpage").UsingFormat(ScreenshotImageFormat.Jpeg));
+            var image = Actor.AsksFor(CurrentScreenshot.SavedTo(Dir, "webpage").UsingFormat(".jpeg"));
             ImagesToDelete.Add(image);
             image.Should().Match(Dir + Path.DirectorySeparatorChar + "webpage*.jpeg");
             Logger.Messages.Should().ContainMatch($"*Screenshots: {Dir}{Path.DirectorySeparatorChar}webpage*.jpeg");
@@ -86,7 +86,7 @@ namespace Boa.Constrictor.Selenium.UnitTests
         [Test]
         public void TestSaveFileWithBmpFormatNoName()
         {
-            var image = Actor.AsksFor(CurrentScreenshot.SavedTo(Dir).UsingFormat(ScreenshotImageFormat.Bmp));
+            var image = Actor.AsksFor(CurrentScreenshot.SavedTo(Dir).UsingFormat(".bmp"));
             ImagesToDelete.Add(image);
             image.Should().Match(Dir + Path.DirectorySeparatorChar + "Screenshot*.bmp");
             Logger.Messages.Should().ContainMatch($"*Screenshots: {Dir}{Path.DirectorySeparatorChar}Screenshot*.bmp");

--- a/Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
+++ b/Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Selenium.Support" Version="4.6.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.6.0" />
+    <PackageReference Include="Selenium.Support" Version="4.14.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">

--- a/Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
+++ b/Boa.Constrictor.Selenium/Boa.Constrictor.Selenium.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Selenium.Support" Version="4.14.1" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
+    <PackageReference Include="Selenium.Support" Version="4.28.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">

--- a/Boa.Constrictor.Selenium/CHANGELOG.md
+++ b/Boa.Constrictor.Selenium/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+### Changed
+
+- Updated `Selenium.Support` and `Selenium.Webdriver` to Version 4.28.0
+- Replaced `ScreenshotImageFormat` with `string` to append to screenshot file formatting path
+- Updated corresponding unit tests to correct for necessary changes
 
 
 ## [4.2.0] - 2024-06-11

--- a/Boa.Constrictor.Selenium/Questions/CurrentScreenshot.cs
+++ b/Boa.Constrictor.Selenium/Questions/CurrentScreenshot.cs
@@ -15,7 +15,7 @@ namespace Boa.Constrictor.Selenium
         /// <summary>
         /// The default screenshot image format.
         /// </summary>
-        public const ScreenshotImageFormat DefaultImageFormat = ScreenshotImageFormat.Png;
+        public const string DefaultImageFormat = ".png";
 
         #endregion
 
@@ -48,7 +48,7 @@ namespace Boa.Constrictor.Selenium
         /// <summary>
         /// Image file format.
         /// </summary>
-        private ScreenshotImageFormat Format { get; set; }
+        private string Format { get; set; }
 
         /// <summary>
         /// The path to the output directory where screenshot image files will be saved.
@@ -73,7 +73,7 @@ namespace Boa.Constrictor.Selenium
         /// </summary>
         /// <param name="format">Image file format.</param>
         /// <returns></returns>
-        public CurrentScreenshot UsingFormat(ScreenshotImageFormat format)
+        public CurrentScreenshot UsingFormat(string format)
         {
             Format = format;
             return this;
@@ -119,7 +119,7 @@ namespace Boa.Constrictor.Selenium
 
             // Capture and save the screenshot.
             string path = Path.Combine(OutputDir, $"{fileName}.{Format.ToString().ToLower()}");
-            (driver as ITakesScreenshot).GetScreenshot().SaveAsFile(path, Format);
+            (driver as ITakesScreenshot).GetScreenshot().SaveAsFile(path);
             actor.Logger.LogArtifact(ArtifactTypes.Screenshots, path);
 
             // Return the path to the screenshot image file.

--- a/Boa.Constrictor.Xunit.UnitTests/Boa.Constrictor.Xunit.UnitTests.csproj
+++ b/Boa.Constrictor.Xunit.UnitTests/Boa.Constrictor.Xunit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Boa.Constrictor/CHANGELOG.md
+++ b/Boa.Constrictor/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+### Changed
+
+- Changed target framework for the unit tests and example projects to .NET 8
+- Changed github artifact actions from `v3` to `v4`
 
 
 ## [4.0.0] - 2023-05-29

--- a/docs/pages/main-docs/tutorial/part-3-rest-api-testing.md
+++ b/docs/pages/main-docs/tutorial/part-3-rest-api-testing.md
@@ -1006,7 +1006,7 @@ However, you should consider using a better output path when running tests in a 
 Rerun the tests, and make sure they all pass.
 Then, check the assembly directory for the dumped files.
 (The assembly file is most likely located at
-`boa-constrictor\Boa.Constrictor.Example\bin\Debug\net7.0`.)
+`boa-constrictor\Boa.Constrictor.Example\bin\Debug\net8.0`.)
 It should contain the following directories:
 
 ```


### PR DESCRIPTION
## Description

A [null pointer vulnerability](https://github.com/seleniumhq/selenium/commit/023a0d52f106321838ab1c0997e76693f4dcbdf6) was found in Selenium in versions prior to 4.14.0 and fixed in version 4.14.1. Updated the corresponding Selenium packages to the latest stable version and corrected the obsoletion of `ScreenshotImageFormat` that occurred in version 4.14.1 to keep current compatibility and limit changes.


### Changes

- Updated `Selenium.Support` and `Selenium.Webdriver` to Version 4.28.0
- `ScreenshotImageFormat` is obsolete within `OpenQA.Selenium` as of v4.14.0. Adjusted use-cases for screenshot image formatting to append the string format to the end of the file path. Adjusted corresponding unit tests to match new method conditions.

## Testing

### Unit Tests
![image](https://github.com/user-attachments/assets/76e968f5-b671-48f6-abc1-5f98622f7e9a)


## Checklist

- [x] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [x] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [x] I successfully built the .NET solution with no errors or new warnings.
- [x] I successfully ran both the unit tests and the example tests.
- [x] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [x] I added documentation for these changes (if appropriate).
