### PR TITLE
Update RestSharp to 112.1.0

### DIFF
--- a/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
+++ b/Boa.Constrictor.RestSharp/Boa.Constrictor.RestSharp.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">

--- a/Boa.Constrictor.RestSharp/CHANGELOG.md
+++ b/Boa.Constrictor.RestSharp/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(none)
+- Updated RestSharp to 112.1.0
 
 
 ## [4.0.0] - 2023-05-29


### PR DESCRIPTION
## Description



My team and I came across a compatibility issue. The particular version of RestSharp Boa uses has a dependency on a specific version System.Text.Json. This has caused us some grief when we changed the available .NET version on our build server.

Later versions of RestSharp have resolved this by referencing different versions depending on the target framework
Boa is years out of date anyhow.


This may introduce any breaking changes RestSharp has introduced in the past couple years. No compatibility issues in the Boa  repo itself, but users may still need to adjust their tests accordingly when they update

We should consider introducing a service like Dependabot to keep dependencies up to date


## Testing

All unit and example tests pass


## Checklist

- [X] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [X] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [X] I successfully built the .NET solution with no errors or new warnings.
- [X] I successfully ran both the unit tests and the example tests.
- [X] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [X] I added documentation for these changes (if appropriate).
