### PR TITLE
Adding the universal "BoaWebLocator" -- A locator that is both an IWebLocator as well as a IPlaywrightLocator

### DIFF
--- a/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
+++ b/Boa.Constrictor.Example/Boa.Constrictor.Example.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Boa.Constrictor.RestSharp\Boa.Constrictor.RestSharp.csproj" />
     <ProjectReference Include="..\Boa.Constrictor.Selenium\Boa.Constrictor.Selenium.csproj" />
+    <ProjectReference Include="..\Boa.Constrictor.Playwright\Boa.Constrictor.Playwright.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Boa.Constrictor.Example/Pages/ArticlePage.cs
+++ b/Boa.Constrictor.Example/Pages/ArticlePage.cs
@@ -1,12 +1,11 @@
-﻿using Boa.Constrictor.Selenium;
+﻿using Boa.Constrictor.Playwright.Elements;
 using OpenQA.Selenium;
-using static Boa.Constrictor.Selenium.WebLocator;
 
 namespace Boa.Constrictor.Example
 {
     public static class ArticlePage
     {
-        public static IWebLocator Title => L(
+        public static BoaWebLocator Title => BoaWebLocator.L(
           "Title Span",
           By.CssSelector("[id='firstHeading'] span"));
     }

--- a/Boa.Constrictor.Example/Pages/ArticlePage.cs
+++ b/Boa.Constrictor.Example/Pages/ArticlePage.cs
@@ -1,4 +1,4 @@
-﻿using Boa.Constrictor.Playwright.Elements;
+﻿using Boa.Constrictor.Playwright;
 using OpenQA.Selenium;
 
 namespace Boa.Constrictor.Example

--- a/Boa.Constrictor.Example/Pages/MainPage.cs
+++ b/Boa.Constrictor.Example/Pages/MainPage.cs
@@ -1,19 +1,18 @@
-﻿using Boa.Constrictor.Selenium;
+﻿using Boa.Constrictor.Playwright.Elements;
 using OpenQA.Selenium;
-using static Boa.Constrictor.Selenium.WebLocator;
-
 namespace Boa.Constrictor.Example
 {
     public static class MainPage
     {
         public const string Url = "https://en.wikipedia.org/wiki/Main_Page";
 
-        public static IWebLocator SearchButton => L(
+        public static BoaWebLocator SearchButton => BoaWebLocator.L(
           "Wikipedia Search Button",
           By.XPath("//button[text()='Search']"));
 
-        public static IWebLocator SearchInput => L(
+        public static BoaWebLocator SearchInput => BoaWebLocator.L(
           "Wikipedia Search Input",
           By.Name("search"));
+
     }
 }

--- a/Boa.Constrictor.Example/Pages/MainPage.cs
+++ b/Boa.Constrictor.Example/Pages/MainPage.cs
@@ -1,4 +1,4 @@
-﻿using Boa.Constrictor.Playwright.Elements;
+﻿using Boa.Constrictor.Playwright;
 using OpenQA.Selenium;
 namespace Boa.Constrictor.Example
 {

--- a/Boa.Constrictor.Playwright.UnitTests/Boa.Constrictor.Playwright.UnitTests.csproj
+++ b/Boa.Constrictor.Playwright.UnitTests/Boa.Constrictor.Playwright.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Boa.Constrictor.Playwright\Boa.Constrictor.Playwright.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Boa.Constrictor.Playwright.UnitTests/Elements/BoaWebLocatorTest.cs
+++ b/Boa.Constrictor.Playwright.UnitTests/Elements/BoaWebLocatorTest.cs
@@ -1,4 +1,3 @@
-using Boa.Constrictor.Playwright.Elements;
 using FluentAssertions;
 using Microsoft.Playwright;
 using Moq;

--- a/Boa.Constrictor.Playwright.UnitTests/Elements/BoaWebLocatorTest.cs
+++ b/Boa.Constrictor.Playwright.UnitTests/Elements/BoaWebLocatorTest.cs
@@ -1,0 +1,249 @@
+using Boa.Constrictor.Playwright.Elements;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Moq;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+
+namespace Boa.Constrictor.Playwright.UnitTests.Elements
+{
+    [TestFixture]
+    public class BoaWebLocatorTests
+    {
+        private Mock<IPage> _mockPage;
+        private Mock<IFrame> _mockFrame;
+        private Mock<ILocator> _mockLocator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockLocator = new Mock<ILocator>();
+            _mockPage = new Mock<IPage>();
+            _mockFrame = new Mock<IFrame>();
+
+            _mockFrame.SetupGet(x => x.Name).Returns("test-frame");
+            _mockPage.Setup(x => x.Locator(It.IsAny<string>(), It.IsAny<PageLocatorOptions>()))
+                .Returns(_mockLocator.Object);
+
+            _mockPage.Setup(x => x.Frame(It.IsAny<string>()))
+                .Returns(_mockFrame.Object);
+
+            _mockFrame.Setup(x => x.Locator(It.IsAny<string>(), It.IsAny<FrameLocatorOptions>()))
+                .Returns(_mockLocator.Object);
+        }
+
+        [Test]
+        public void L_WithEmptyDescription_UsesQueryMechanismAsDescription()
+        {
+            // Arrange
+            var baseLocator = new BoaWebLocator("test", By.Id("testId"));
+            var query = By.Id("newId");
+
+            // Act
+            var result = baseLocator.L(query, "");
+
+            // Assert
+            result.Description.Should().Be($"{query.Mechanism}:\n{query.Criteria}\n");
+        }
+
+        [Test]
+        public void FindIn_WithPageHavingNoFrames_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.Id("testId"));
+            var emptyFramesList = new List<IFrame>();
+            _mockPage.SetupGet(x => x.Frames).Returns(emptyFramesList);
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object));
+        }
+
+        [Test]
+        public void FindIn_WithPageHavingFrames_UsesFirstFrame()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.Id("testId"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("first-frame");
+            var mockFrame2 = new Mock<IFrame>();
+            mockFrame2.SetupGet(x => x.Name).Returns("second-frame");
+
+            var framesList = new List<IFrame> { mockFrame1.Object, mockFrame2.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            _mockPage.Verify(x => x.Frame("first-frame"), Times.Once);
+            _mockPage.Verify(x => x.Frame("second-frame"), Times.Never);
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithId_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.Id("testId"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithClassName_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.ClassName("test-class"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithTagName_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.TagName("div"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithName_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.Name("test-name"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithCssSelector_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.CssSelector(".custom-selector"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithXPath_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.XPath("//div[@id='test']"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithLinkText_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.LinkText("Click here"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void ConvertSeleniumByToPlaywrightSelector_WithPartialLinkText_ReturnsCorrectSelector()
+        {
+            // Arrange
+            var boaLocator = new BoaWebLocator("test", By.PartialLinkText("Click"));
+            var mockFrame1 = new Mock<IFrame>();
+            mockFrame1.SetupGet(x => x.Name).Returns("frame1");
+            var framesList = new List<IFrame> { mockFrame1.Object };
+            _mockPage.SetupGet(x => x.Frames).Returns(framesList);
+
+            // Act
+            var result = ((IPlaywrightLocator)boaLocator).FindIn(_mockPage.Object);
+
+            // Assert
+            result.Should().Be(_mockLocator.Object);
+        }
+
+        [Test]
+        public void L_WithDifferentByTypes_CreatesCorrectLocators()
+        {
+            // Arrange
+            var baseLocator = new BoaWebLocator("test", By.Id("testId"));
+
+            // Test various By types
+            var byId = By.Id("elementId");
+            var byClassName = By.ClassName("class-name");
+            var byTagName = By.TagName("div");
+            var byXPath = By.XPath("//div[@id='test']");
+            var byCssSelector = By.CssSelector(".selector");
+
+            // Act
+            var locatorId = baseLocator.L(byId, "ID Locator");
+            var locatorClass = baseLocator.L(byClassName, "Class Locator");
+            var locatorTag = baseLocator.L(byTagName, "Tag Locator");
+            var locatorXPath = baseLocator.L(byXPath, "XPath Locator");
+            var locatorCss = baseLocator.L(byCssSelector, "CSS Locator");
+
+            // Assert Selenium locators work
+            locatorId.Query.Should().Be(byId);
+            locatorClass.Query.Should().Be(byClassName);
+            locatorTag.Query.Should().Be(byTagName);
+            locatorXPath.Query.Should().Be(byXPath);
+            locatorCss.Query.Should().Be(byCssSelector);
+        }
+    }
+}

--- a/Boa.Constrictor.Playwright.UnitTests/Elements/PlaywrightLocatorTests.cs
+++ b/Boa.Constrictor.Playwright.UnitTests/Elements/PlaywrightLocatorTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using Moq;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Boa.Constrictor.Playwright.UnitTests.Elements
+{
+    [TestFixture]
+    public class PlaywrightLocatorTests
+    {
+        [Test]
+        public void FindInTest()
+        {
+            // Arrange
+            var mockLocator = new Mock<ILocator>();
+            mockLocator
+                .Setup(x => x.InnerTextAsync(It.IsAny<LocatorInnerTextOptions>()))
+                .Returns(Task.FromResult("a"));
+
+            var mockPage = new Mock<IPage>();
+            mockPage
+                .Setup(x => x.Locator(It.IsAny<string>(), It.IsAny<PageLocatorOptions>()))
+                .Returns(mockLocator.Object);
+            var locator = new PlaywrightLocator("Description", x => x.Locator("Test"));
+
+            // Act
+            var result = locator.FindIn(mockPage.Object);
+
+            // Assert
+            result.Should().BeEquivalentTo(mockLocator.Object);
+            result.InnerTextAsync().Result.Should().Be("a");
+        }
+    }
+}

--- a/Boa.Constrictor.Playwright/Abilities/BrowseTheWebWithPlaywright.cs
+++ b/Boa.Constrictor.Playwright/Abilities/BrowseTheWebWithPlaywright.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Boa.Constrictor.Screenplay;
+using Microsoft.Playwright;
+
+namespace Boa.Constrictor.Playwright
+{
+    /// <summary>
+    ///     Enables the Actor to use a Web browser via Playwright
+    /// </summary>
+    public class BrowseTheWebWithPlaywright : IAbility
+    {
+        /// <summary>
+        ///     Private constructor.
+        ///     (Use the static methods for public construction.)
+        /// </summary>
+        /// <param name="playwright">The Playwright instance</param>
+        /// <param name="browser">The Playwright browser instance</param>
+        private BrowseTheWebWithPlaywright(IPlaywright playwright, IBrowser browser)
+        {
+            Playwright = playwright;
+            Browser = browser;
+            Pages = new List<IPage>();
+        }
+
+        /// <summary>
+        /// The <see cref="IPlaywright"/> instance
+        /// </summary>
+        public IPlaywright Playwright { get; }
+        
+        /// <summary>
+        /// The <see cref="IBrowser"/> instance
+        /// </summary>
+        public IBrowser Browser { get; set; }
+        
+        /// <summary>
+        /// A collection of open pages
+        /// </summary>
+        public IList<IPage> Pages { get; }
+        
+        /// <summary>
+        /// The currently active page
+        /// </summary>
+        public  IPage CurrentPage { get; set; }
+
+        /// <summary>
+        /// The browser context
+        /// </summary>
+        public IBrowserContext BrowserContext { get; set; }
+
+
+        /// <summary>
+        ///     Supply a pre-defined Plawright browser to use
+        /// </summary>
+        /// <param name="playwright">The Playwright instance</param>
+        /// <param name="browser">The Playwright browser instance.</param>
+        /// <returns>An instance of <see cref="BrowseTheWebWithPlaywright" /></returns>
+        public static BrowseTheWebWithPlaywright Using(IPlaywright playwright, IBrowser browser)
+        {
+            return new BrowseTheWebWithPlaywright(playwright, browser);
+        }
+
+        /// <summary>
+        ///     Use a Chromium (i.e. Chrome, Edge, Opera, etc.) browser.
+        /// </summary>
+        /// <returns>An instance of <see cref="BrowseTheWebWithPlaywright" /> configured to use Chromium</returns>
+        public static async Task<BrowseTheWebWithPlaywright> UsingChromium(BrowserTypeLaunchOptions options = null)
+        {
+            var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+            var browser = await playwright.Chromium.LaunchAsync(options);
+            return new BrowseTheWebWithPlaywright(playwright, browser);
+        }
+
+        /// <summary>
+        ///     Use a Firefox browser
+        /// </summary>
+        /// <returns>An instance of <see cref="BrowseTheWebWithPlaywright" /> configured to use firefox</returns>
+        public static async Task<BrowseTheWebWithPlaywright> UsingFirefox(BrowserTypeLaunchOptions options = null)
+        {
+            var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+            var browser = await playwright.Firefox.LaunchAsync(options);
+            return new BrowseTheWebWithPlaywright(playwright, browser);
+        }
+
+        /// <summary>
+        ///     Use a WebKit (i.e. Safari, etc.) browser.
+        /// </summary>
+        /// <returns>An instance of <see cref="BrowseTheWebWithPlaywright" /> configured to use Webkit</returns>
+        public static async Task<BrowseTheWebWithPlaywright> UsingWebkit(BrowserTypeLaunchOptions options = null)
+        {
+            var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+            var browser = await playwright.Webkit.LaunchAsync(options);
+            return new BrowseTheWebWithPlaywright(playwright, browser);
+        }
+
+        /// <summary>
+        /// Gets the current page. If no page exists, a new page is created.
+        /// </summary>
+        /// <returns>The current page.</returns>
+        public async Task<IPage> GetCurrentPageAsync()
+        {
+            if (CurrentPage == null)
+            {
+                var context = await GetBrowserContextAsync();
+                CurrentPage = await context.NewPageAsync();
+                Pages.Add(CurrentPage);
+            }
+
+            return CurrentPage;
+        }
+        
+        /// <summary>
+        /// Gets the current browser context. If no context exists, a new one is created.
+        /// </summary>
+        /// <returns>The current browser context.</returns>
+        public async Task<IBrowserContext> GetBrowserContextAsync()
+        {
+            if (BrowserContext == null)
+            {
+                BrowserContext = await Browser.NewContextAsync();
+            }
+
+            return BrowserContext;
+        }
+
+        /// <summary>
+        ///     Returns a description of this Ability
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"browse the web with playwright using {Browser.BrowserType.Name}";
+        }
+    }
+}

--- a/Boa.Constrictor.Playwright/Boa.Constrictor.Playwright.csproj
+++ b/Boa.Constrictor.Playwright/Boa.Constrictor.Playwright.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <Version>4.0.0</Version>
+        <Authors>Keith Tremorin, Tom Shaffer</Authors>
+        <Company>Q2</Company>
+        <Title>Boa.Constrictor.Playwright</Title>
+        <Product>Boa.Constrictor.Playwright</Product>
+        <Description>Boa Constrictor is the .NET Screenplay Pattern! This package is the Playwright support library.</Description>
+        <Copyright>Copyright © 2020-2023 Q2 Holdings Inc.</Copyright>
+        <RepositoryUrl>https://github.com/q2ebanking/boa-constrictor</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <DebugType>embedded</DebugType>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReleaseNotes>Please read https://github.com/q2ebanking/boa-constrictor/blob/main/Boa.Constrictor.Playwright/CHANGELOG.md for full release notes.</PackageReleaseNotes>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="../logos/symbol/no-margin/png/logo-symbol-black-120x148.png" Pack="true" PackagePath="$(PackageIcon)" />
+        <None Include="../LICENSE.md" Pack="true" PackagePath="$(PackageLicenseFile)" />
+        <None Include="README.md" Pack="true" PackagePath="$(PackageReadmeFile)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)' == 'Release'">
+        <PackageReference Include="Boa.Constrictor.Screenplay" Version="4.0.0" />
+        <PackageReference Include="Boa.Constrictor.Selenium" Version="4.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+        <ProjectReference Include="..\Boa.Constrictor.Screenplay\Boa.Constrictor.Screenplay.csproj" />
+        <ProjectReference Include="..\Boa.Constrictor.Selenium\Boa.Constrictor.Selenium.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Playwright" Version="1.43.0" />
+    </ItemGroup>
+
+</Project>

--- a/Boa.Constrictor.Playwright/CHANGELOG.md
+++ b/Boa.Constrictor.Playwright/CHANGELOG.md
@@ -1,0 +1,13 @@
+﻿# Changelog
+
+This file documents all notable changes to the Boa.Constrictor.Playwright project and its unit tests for each NuGet package release.
+
+Its format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+
+- Added project `Boa.Constrictor.Playwright` for items that improve [Playwright](https://playwright.dev/dotnet/) support 
+- Added `IPlaywrightLocator` interface and implementation, which will be used to create locators for Playwright
+- Added `IBoaWebLocator` interface and implementation, which can be used to easily convert Selenium IWebLocators into Playwright IPlaywrightLocators

--- a/Boa.Constrictor.Playwright/Elements/BoaWebLocator.cs
+++ b/Boa.Constrictor.Playwright/Elements/BoaWebLocator.cs
@@ -3,7 +3,7 @@ using Microsoft.Playwright;
 using OpenQA.Selenium;
 using System;
 
-namespace Boa.Constrictor.Playwright.Elements
+namespace Boa.Constrictor.Playwright
 {
     /// <summary>
     /// Serves as both the IWebLocator for Selenium code, but also as the IPlaywrightLocator for Playwright code.

--- a/Boa.Constrictor.Playwright/Elements/BoaWebLocator.cs
+++ b/Boa.Constrictor.Playwright/Elements/BoaWebLocator.cs
@@ -1,0 +1,105 @@
+﻿using Boa.Constrictor.Selenium;
+using Microsoft.Playwright;
+using OpenQA.Selenium;
+using System;
+
+namespace Boa.Constrictor.Playwright.Elements
+{
+    /// <summary>
+    /// Serves as both the IWebLocator for Selenium code, but also as the IPlaywrightLocator for Playwright code.
+    /// </summary>
+    public class BoaWebLocator : WebLocator, IPlaywrightLocator, IBoaWebLocator
+    {
+        /// <summary>
+        /// Constructor to make a BoaWebLocator using the Selenium By.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <param name="query"></param>
+        public BoaWebLocator(string description, By query) : base(description, query) { }
+
+        string IPlaywrightLocator.Description { get => Description; set => throw new NotImplementedException(); }
+
+        private IPlaywrightLocator PlaywrightLocator { get; set; }
+
+        /// <summary>
+        /// Extension method to format the description of the weblocator for exceptions and logging
+        /// </summary>
+        /// <param name="description">Description for the query</param>
+        /// <param name="query">By object to be used to query for a specific BoaWebLocator</param>
+        /// <returns></returns>
+        public static new BoaWebLocator L(string description, By query) => new BoaWebLocator(description, query);
+
+        /// <summary>
+        /// Extension method to format the description of the weblocator for exceptions and logging
+        /// </summary>
+        /// <param name="description">Description for the query</param>
+        /// <param name="query">By object to be used to query for a specific BoaWebLocator</param>
+        /// <returns></returns>
+        public BoaWebLocator L(By query, string description = null)
+        {
+            if (string.IsNullOrEmpty(description))
+                description = query.Mechanism;
+
+            string formattedDescription = $"{description}:\n{query.Criteria}\n";
+            return new BoaWebLocator(formattedDescription, query);
+        }
+
+        ILocator IPlaywrightLocator.FindIn(IPage page)
+        {
+            PlaywrightLocator = ConvertToPlaywrightLocator(page);
+            return PlaywrightLocator.FindIn(page);
+        }
+
+        /// <summary>
+        /// Converts the wrapped BoaWebLocator to a PlaywrightLocator
+        /// </summary>
+        private PlaywrightLocator ConvertToPlaywrightLocator(IPage page, IFrame frame = null)
+        {
+            string playwrightSelector = ConvertSeleniumByToPlaywrightSelector(Query);
+
+            if (frame == null)
+                if (page.Frames.Count > 0)
+                    frame = page.Frames[0]; // Default to the first frame if no specific frame is provided
+                else
+                    throw new ArgumentNullException(nameof(frame), "No frame found and no specific frame provided.");
+
+            return new PlaywrightLocator(
+                Description,
+                selector => frame != null ? page.Frame(frame.Name).Locator(playwrightSelector) : page.Locator(playwrightSelector)
+            );
+        }
+
+        /// <summary>
+        /// Converts a Selenium By locator to a Playwright selector string.
+        /// </summary>
+        /// <param name="by">The Selenium By locator.</param>
+        /// <returns>A Playwright selector string.</returns>
+        private static string ConvertSeleniumByToPlaywrightSelector(By by)
+        {
+            string mechanism = by.ToString().Split(':')[0].Split('[')[0].Trim();
+            string criteria = by.Criteria;
+
+            switch (mechanism.ToLower())
+            {
+                case "by.id":
+                    return $"#{criteria}";
+                case "by.classname":
+                    return $".{criteria}";
+                case "by.tagname":
+                    return criteria;
+                case "by.name":
+                    return $"[name='{criteria}']";
+                case "by.cssselector":
+                    return criteria;
+                case "by.xpath":
+                    return $"xpath={criteria}";
+                case "by.linktext":
+                    return $"text={criteria}";
+                case "by.partiallinktext":
+                    return $"text='{criteria}'";
+                default:
+                    throw new NotSupportedException($"Unsupported Selenium locator type: {mechanism}");
+            }
+        }
+    }
+}

--- a/Boa.Constrictor.Playwright/Elements/BoaWebLocator.cs
+++ b/Boa.Constrictor.Playwright/Elements/BoaWebLocator.cs
@@ -56,16 +56,31 @@ namespace Boa.Constrictor.Playwright
         private PlaywrightLocator ConvertToPlaywrightLocator(IPage page, IFrame frame = null)
         {
             string playwrightSelector = ConvertSeleniumByToPlaywrightSelector(Query);
-
+            
+            // Check if a frame was explicitly provided
             if (frame == null)
-                if (page.Frames.Count > 0)
-                    frame = page.Frames[0]; // Default to the first frame if no specific frame is provided
+            {
+                // Get the browser context from the page
+                var browserContext = page.Context;
+                
+                // Try to get the associated ability from our registry
+                var ability = BrowseTheWebWithPlaywright.GetForContext(browserContext);
+                
+                // If we found the ability and it has a current frame, use it
+                if (ability != null && ability.CurrentFrame != null)
+                {
+                    frame = ability.CurrentFrame;
+                }
                 else
-                    throw new ArgumentNullException(nameof(frame), "No frame found and no specific frame provided.");
+                {
+                    // If no frame is found, use the main frame
+                    frame = page.MainFrame;
+                }
+            }
 
             return new PlaywrightLocator(
                 Description,
-                selector => frame != null ? page.Frame(frame.Name).Locator(playwrightSelector) : page.Locator(playwrightSelector)
+                selector => page.Frame(frame.Name).Locator(playwrightSelector)
             );
         }
 

--- a/Boa.Constrictor.Playwright/Elements/IBoaWebLocator.cs
+++ b/Boa.Constrictor.Playwright/Elements/IBoaWebLocator.cs
@@ -1,6 +1,6 @@
 ﻿using OpenQA.Selenium;
 
-namespace Boa.Constrictor.Playwright.Elements
+namespace Boa.Constrictor.Playwright
 {
     /// <summary>
     /// Interface for BoaWebLocator utilities.

--- a/Boa.Constrictor.Playwright/Elements/IBoaWebLocator.cs
+++ b/Boa.Constrictor.Playwright/Elements/IBoaWebLocator.cs
@@ -1,0 +1,18 @@
+﻿using OpenQA.Selenium;
+
+namespace Boa.Constrictor.Playwright.Elements
+{
+    /// <summary>
+    /// Interface for BoaWebLocator utilities.
+    /// </summary>
+    public interface IBoaWebLocator
+    {
+        /// <summary>
+        /// Creates a BoaWebLocator instance with the specified query and description.
+        /// </summary>
+        /// <param name="query">The Selenium By query.</param>
+        /// <param name="description">The description of the locator.</param>
+        /// <returns>A new BoaWebLocator instance.</returns>
+        BoaWebLocator L(By query, string description = null);
+    }
+}

--- a/Boa.Constrictor.Playwright/Elements/IPlaywrightLocator.cs
+++ b/Boa.Constrictor.Playwright/Elements/IPlaywrightLocator.cs
@@ -1,0 +1,22 @@
+namespace Boa.Constrictor.Playwright
+{
+    using Microsoft.Playwright;
+
+    /// <summary>
+    /// An interface for finding locators on a page.
+    /// </summary>
+    public interface IPlaywrightLocator
+    {
+        /// <summary>
+        /// Plain-language description of the Locator (used for logging)
+        /// </summary>
+        string Description { get; set; }
+
+        /// <summary>
+        /// Finds the locator in the specified page.
+        /// </summary>
+        /// <param name="page">The page to search for this locator.</param>
+        /// <returns></returns>
+        ILocator FindIn(IPage page);
+    }
+}

--- a/Boa.Constrictor.Playwright/Elements/PlaywrightLocator.cs
+++ b/Boa.Constrictor.Playwright/Elements/PlaywrightLocator.cs
@@ -1,0 +1,66 @@
+namespace Boa.Constrictor.Playwright
+{
+    using System;
+    using Microsoft.Playwright;
+
+    /// <summary>
+    /// The concrete implementation of IPlaywrightLocator.
+    /// </summary>
+    public class PlaywrightLocator : IPlaywrightLocator
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="description">Plain-language description of the Locator (used for logging).</param>
+        /// <param name="selectorFunc">A function to find a locator on a page.</param>
+        public PlaywrightLocator(string description, Func<IPage, ILocator> selectorFunc)
+        {
+            Description = description;
+            SelectorFunc = selectorFunc;
+        }
+
+        /// <summary>
+        /// Plain-language description of the Locator (used for logging)
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// A function to find a locator on a page.
+        /// </summary>
+        private Func<IPage, ILocator> SelectorFunc { get; set; }
+
+
+        /// <summary>
+        /// Convenient builder method for construction PlaywrightLocator objects without too much text.
+        /// </summary>
+        /// <param name="description">Plain-language description of the Locator (used for logging).</param>
+        /// <param name="selectorFunc">A function to find a locator on a page.</param>
+        /// <returns></returns>
+        public static PlaywrightLocator L(string description, Func<IPage, ILocator> selectorFunc)
+        {
+            return new PlaywrightLocator(description, selectorFunc);
+        }
+
+        /// <summary>
+        /// Convenient builder method for construction PlaywrightLocator objects without too much text.
+        /// </summary>
+        /// <param name="description">Plain-language description of the Locator (used for logging).</param>
+        /// <param name="selector">selector used to resolve DOM elements</param>
+        /// <param name="options">Call options</param>
+        /// <returns></returns>
+        public static PlaywrightLocator L(string description, string selector, PageLocatorOptions options = null)
+        {
+            return new PlaywrightLocator(description, page => page.Locator(selector, options));
+        }
+
+        /// <summary>
+        /// Finds the locator in the specified page.
+        /// </summary>
+        /// <param name="page">The page to search for this locator.</param>
+        /// <returns></returns>
+        public ILocator FindIn(IPage page)
+        {
+            return SelectorFunc.Invoke(page);
+        }
+    }
+}

--- a/Boa.Constrictor.Playwright/README.md
+++ b/Boa.Constrictor.Playwright/README.md
@@ -1,0 +1,40 @@
+
+---
+
+![Boa Constrictor Logo](https://raw.githubusercontent.com/q2ebanking/boa-constrictor/main/logos/title/no-margin/png/logo-title-black-400x64.png)
+
+---
+[![BoaConstrictor](https://img.shields.io/badge/boa%20constrictor%20-The%20.NET%20Screenplay%20Pattern-blueviolet?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAATCAYAAABPwleqAAAACXBIWXMAAAWJAAAFiQFtaJ36AAABAUlEQVQ4jY2T623CQBCEP6L8xyW4A6ACKCEdxCWEDkgHUAHQQTpISnA6IB2YCjYatIeO5fwY6WTt+eY8s7PGzErrZGVczKxJ50vE2sy6HnKCLmd2u+EZS2AfditgkdXbSK6cGNEBLdAAR3/3l6RWZrYfkZq83i0lcjtCND9DvvEK7IKXX+DHpeZQDx4sybMOzb0+AB893uX3PavPBGkb9z9mQ77rSJ6a81fKOc9q5ZFI8luIcBN68ynyKfNy9Qa2U3OeItOGcl760A9B7x96FMezcb8xJsmWPT2/85wLo/yUs2rlv445xzU555eer9YlOQ6Nr2K7DP3Pec4JmnktAP4BJn0sgWz0+e4AAAAASUVORK5CYII=
+)](https://github.com/q2ebanking/boa-constrictor)
+[![NugetPackage](https://img.shields.io/nuget/v/Boa.Constrictor.Xunit?label=NuGet%20Package)](https://www.nuget.org/packages/Boa.Constrictor.Xunit/)
+[![NugetDownloads](https://img.shields.io/nuget/dt/Boa.Constrictor.Xunit)](https://www.nuget.org/stats/packages/Boa.Constrictor.Xunit?groupby=Version)
+[![Contributors](https://img.shields.io/github/contributors/q2ebanking/boa-constrictor)](https://github.com/q2ebanking/boa-constrictor/graphs/contributors)
+[![Commits](https://img.shields.io/github/commit-activity/m/q2ebanking/boa-constrictor)](https://github.com/q2ebanking/boa-constrictor/commits/main)
+[![OpenPullRequests](https://img.shields.io/github/issues-pr/q2ebanking/boa-constrictor)](https://github.com/q2ebanking/boa-constrictor/pulls)
+[![OpenIssues](https://img.shields.io/github/issues/q2ebanking/boa-constrictor)](https://github.com/q2ebanking/boa-constrictor/issues)
+[![License](https://img.shields.io/badge/license-Apache%202-blue)](./LICENSE.md)
+[![Hacktoberfest](https://img.shields.io/github/hacktoberfest/2021/q2ebanking/boa-constrictor)](https://github.com/q2ebanking/boa-constrictor/issues)
+
+
+## What is Boa Constrictor?
+
+**Boa Constrictor** is the .NET Screenplay Pattern.
+It helps you make *better interactions* for *better automation*!
+
+The Screenplay Pattern can be summarized in one line:
+*Actors* use *Abilities* to perform *Interactions*.
+
+
+## What is this package?
+
+`Boa.Constrictor.Playwright` is the support library for [Playwright](https://playwright.dev/dotnet/).
+
+
+## How do I get started?
+
+* Visit the [GitHub Pages doc site](https://q2ebanking.github.io/boa-constrictor/) to learn how to use it.
+* Take the [official tutorial](https://q2ebanking.github.io/boa-constrictor/tutorial/overview/) to get your hands dirty with the code.
+* See the latest changes in the [project changelog](https://github.com/q2ebanking/boa-constrictor/blob/main/Boa.Constrictor.Xunit/CHANGELOG.md).
+* Review the [contributing guide](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) and the [code of conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/) for contributing to the project.
+* Join our [Discord server](https://discord.gg/pP3dXzYQ82)
+  to collaborate with the community.

--- a/Boa.Constrictor.sln
+++ b/Boa.Constrictor.sln
@@ -63,6 +63,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Boa.Constrictor.Xunit", "Bo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Boa.Constrictor.Xunit.UnitTests", "Boa.Constrictor.Xunit.UnitTests\Boa.Constrictor.Xunit.UnitTests.csproj", "{A49F6E9F-EBFC-4391-83A2-66646F9C2895}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Boa.Constrictor.Playwright", "Boa.Constrictor.Playwright\Boa.Constrictor.Playwright.csproj", "{8B41C812-118F-4F45-B57C-D75AA565B402}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Boa.Constrictor.Playwright.UnitTests", "Boa.Constrictor.Playwright.UnitTests\Boa.Constrictor.Playwright.UnitTests.csproj", "{854FEC42-C6C9-4986-9088-E81894B81662}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
This locator allows you to easily convert from Selenium to Playwright locators... Let me know if you have a better name

## Description

> Please explain the changes included in this pull request.

I know this is a bit of dramatic change, we can scale it back and implement it slower, just wanted to demonstrate that it worked everywhere.

Basically, I just added a new locator that can operate as both a Boa.Constrictor.Selenium IWebLocator but also a Boa.Constrictor.Playwright IPlaywrightLocator. This is really a useful abstraction because you can essentially re-use all your existing IWebLocators in your Selenium project, and simply drop them in and start using Playwright Boa.

I've been using this today as a drop in replacement for our Playwright transition and it has worked really well for me, so I decided to take the time and adapt it into the Boa repo. If you did want to use this in your own transition, all you'll have to do is replace your "IWebLocators" with "BoaWebLocators"

## Testing

> Please explain the testing done for these changes.
> Include unit tests and feature tests.

I have added some extensive unit tests to prove that the BoaWebLocator works as intended to both translate IWebLocators but also to function as an IPlaywrightLocator.

I also went ahead and moved the examples to use this new locator just to prove it works with the older stuff.

In addition, I applied these locators on top of ThePantz's PR where he is creating the Playwright Boa project. The tests pass using the new locator... Which makes sense since it's just a class that meets both the IWebLocator and IPlaywrightLocator interfaces.

We also use this in our own code, we'd prefer to get this in the official Nuget, so I haven't tested with these code changes specifically yet, but I built out a home grown version of this and that is what we've been using on our code and it has made the tranition to Boa Playwright a lot easier.


## Checklist

- [X] I agree to follow Boa Constrictor's [Code of Conduct](https://q2ebanking.github.io/boa-constrictor/contributing/code-of-conduct/).
- [X] I read Boa Constrictor's [Contributing Code](https://q2ebanking.github.io/boa-constrictor/contributing/contributing-code/) guide.
- [X] I successfully built the .NET solution with no errors or new warnings.
- [X] I successfully ran both the unit tests and the example tests.
- [X] I updated the [appropriate changelogs](CHANGELOG.md) with concise descriptions of these changes.
- [ ] I added documentation for these changes (if appropriate). **I want to make sure my change is wanted before I document it... incase I am just missing some obvious way to do this and this PR isn't necessary**
